### PR TITLE
Implement OpenMP target offload GPU backend.

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -37,7 +37,12 @@ jobs:
           python3.13 -m pip install uv
           uv sync
 
-      - name: compile and run tests
+      - name: compile and run tests (OpenACC mode)
         run: |
           cd tests
           NUM_PROCS=2 arch=nvidia OPENACC=1 ./test_runner.sh
+
+      - name: compile and run tests (OpenMP mode)
+        run: |
+          cd tests
+          NUM_PROCS=2 arch=nvidia OPENMP=1 ./test_runner.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 AGILE is a GPU-enabled fork of MPI-AMRVAC, a Fortran finite-volume code for
 solving hyperbolic PDEs (HD, MHD, FFHD, SRHD) with adaptive mesh refinement.
-Master currently only supports 3D Cartesian grids. Domain decomposition and
-GPU offload use MPI + OpenACC (`!$acc` directives throughout the hot loops).
+Master currently only supports 3D Cartesian grids. Domain decomposition uses
+MPI; GPU offload supports two selectable backends, OpenACC and OpenMP target
+offload. Every offload site in the hot loops is written once as a call to a
+macro from `src/mod_gpu_directives.fpp` (e.g. `${GPU_PARALLEL_LOOP(...)}$`),
+which fypp expands to the matching `!$acc ...` or `!$omp target ...`
+directive depending on which backend is selected at build time (see
+`OPENACC=1`/`OPENMP=1` below) — don't write raw `!$acc`/`!$omp` directives
+directly in hot-loop code, add a macro call instead.
 
 Source is written as `.fpp` files (Fortran + `fypp` preprocessor directives,
 e.g. `#:if PHYS == 'hd'`) which get preprocessed into `.f90` before
@@ -38,7 +44,8 @@ parameter file. Build from inside such a directory:
 ```bash
 cd tests/hd/KH3D
 make arch=gnu              # compiles and links ./agile executable
-make arch=gnu OPENACC=1    # enable GPU/OpenACC build
+make arch=gnu OPENACC=1    # enable GPU build with the OpenACC backend
+make arch=gnu OPENMP=1     # enable GPU build with the OpenMP target-offload backend
 make arch=gnu DEBUG=1      # debug flags (-g -O0 -fcheck=all, etc.)
 make clean                 # remove this case's build products
 ```
@@ -46,6 +53,9 @@ make clean                 # remove this case's build products
 - `arch` selects a file from `arch/*.mk` (`gnu`, `ifx`, `nvidia`, `cray`,
   `llvm`) which sets the compiler/linker and flags. Default is `gnu`
   (`mpif90`/gfortran).
+- `OPENACC` and `OPENMP` are mutually exclusive GPU offload backend switches
+  (`make` errors out if both are given); neither flag gives a plain CPU
+  build, where every `GPU_*` directive macro expands to nothing.
 - Physics-relevant compile-time options (which physics module, tracers,
   gravity, cooling, thermal conduction, etc.) are declared in `agile.par` and
   turned into `config.mk`/fypp defines by `make/config_reader.py`, validated
@@ -110,16 +120,24 @@ fypp define consumed by `src/physics/mod_physics.fpp` and the per-physics
 
 ## Code architecture
 
-- `src/agile.fpp` — program entry point (`program agile`): MPI init, OpenACC
-  device selection, then `main()` which reads parameters, calls
+- `src/agile.fpp` — program entry point (`program agile`): MPI init, GPU
+  device selection (`set_openacc_device`/`set_openmp_device`, whichever
+  backend is active), then `main()` which reads parameters, calls
   `usr_init()`, initializes the AMR tree, and runs `timeintegration()` (the
   main time-stepping loop: `setdt` → optional user process hooks → I/O →
   `advance` → AMR regrid → loop).
 - `src/mod_global_parameters.fpp` — the large module of shared global state
   (grid geometry, ghost cells, timers, I/O settings) used throughout.
+- `src/mod_gpu_directives.fpp` — fypp macro definitions (`GPU_PARALLEL_LOOP`,
+  `GPU_ROUTINE_SEQ`, `GPU_ENTER_DATA_COPYIN`, `GPU_HOST_DATA_USE_DEVICE`,
+  etc.) that expand to OpenACC or OpenMP-target directives depending on the
+  active backend; `src/mod_gpu_utils.fpp` (module `gpu_utils`) provides the
+  `copy_or_update`/`copy_or_update_pointer`/`copy_or_update_alloc` helpers
+  used when re-allocating AMR grid data on the device.
 - `src/mod_advance.fpp`, `src/mod_finite_volume.fpp` — the finite-volume
-  update step; these contain the performance-critical OpenACC-annotated
-  loops (`!$acc parallel loop`, `!$acc routine seq`, etc.).
+  update step; these contain the performance-critical GPU-offloaded loops,
+  written via the `GPU_*` directive macros (`GPU_PARALLEL_LOOP`,
+  `GPU_ROUTINE_SEQ`, etc.) rather than raw `!$acc`/`!$omp` directives.
 - `src/amr/` — the block-based octree AMR machinery: forest/tree bookkeeping
   (`mod_forest.fpp`), refinement/coarsening, load balancing, space-filling
   curve ordering, flux correction at refinement boundaries

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ module purge
 module load 2023
 module load OpenMPI/4.1.5-NVHPC-24.5-CUDA-12.1.1
 ```
-- compile with nvfortran and activated OPENACC via `make arch=nvidia OPENACC=1`
+- compile with nvfortran and the OpenACC GPU backend via `make arch=nvidia OPENACC=1`,
+  or the OpenMP target-offload backend via `make arch=nvidia OPENMP=1`
+  (`OPENACC` and `OPENMP` are mutually exclusive)
 
 
 ## Currently supported features on master

--- a/arch/llvm.mk
+++ b/arch/llvm.mk
@@ -2,5 +2,12 @@ arch := llvm
 
 compile = flang
 f90_flags += -ffree-form -fimplicit-none -cpp $(shell mpifort --showme:compile)
+
+ifdef OPENMP
+$(info Enabling OpenMP)
+enabled += OPENMP
+f90_flags += -fopenmp
+endif
+
 link_flags += $(f90_flags) $(shell mpifort --showme:link)
 

--- a/arch/nvidia.mk
+++ b/arch/nvidia.mk
@@ -10,16 +10,26 @@ f90_flags += -DNVTX
 link_flags += -lnvToolsExt
 endif
 
-ifdef OPENMP
-$(info Enabling OpenMP)
-enabled += OPENMP
-f90_flags += -fopenmp
-endif
-
 ifdef OPENACC
 $(info Enabling OpenACC)
 f90_flags += -Wall -acc=gpu
 enabled += OPENACC
+ifdef NOGPUDIRECT
+$(info Disabling direct GPU-GPU copies)
+f90_flags += -DNOGPUDIRECT
+enabled += NOGPUDIRECT
+endif
+ifdef DEBUG
+f90_flags += -gpu=debug -Mvect=levels:0 -Mnoinline
+else
+f90_flags += -Mvect=levels:5 -Minline
+endif
+endif
+
+ifdef OPENMP
+$(info Enabling OpenMP)
+f90_flags += -Wall -mp=gpu
+enabled += OPENMP
 ifdef NOGPUDIRECT
 $(info Disabling direct GPU-GPU copies)
 f90_flags += -DNOGPUDIRECT

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -31,10 +31,15 @@ title: Getting started
         module load 2023
         module load OpenMPI/4.1.5-NVHPC-24.5-CUDA-12.1.1
 
-* Compile with `nvfortran` and OpenACC activated via
+* Compile with `nvfortran` and the OpenACC GPU backend activated via
 
         make arch=nvidia OPENACC=1
 
+  or the OpenMP target-offload backend via
+
+        make arch=nvidia OPENMP=1
+
+  (`OPENACC` and `OPENMP` are mutually exclusive GPU offload backends).
   For a plain CPU build (`gfortran`/OpenMPI, no GPU toolchain required),
   use `make arch=gnu` instead.
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -25,7 +25,7 @@ included; the hydrodynamics and the magnetohydrodynamics module are most
 frequently used. Users can add their own physics module or modify existing ones.
 At present, the framework supports only 3D simulations in Cartesian grid geometries.  
 
-AGILE is written in Fortran 2003, uses OpenACC for GPU offloading and MPI for parallelization.
+AGILE is written in Fortran 2003, uses OpenACC or OpenMP target offloading (selectable at build time) for GPU offloading, and MPI for parallelization.
 
 The philosophy behind AGILE is to use a single versatile code with options
 and switches for various problems. The advantage of such a general approach is

--- a/make/30-fypp.mk
+++ b/make/30-fypp.mk
@@ -2,6 +2,16 @@ ifdef DEBUG
 fypp_flags += -DDEBUG
 endif
 
+ifdef OPENACC
+ifdef OPENMP
+$(error OPENACC and OPENMP are mutually exclusive GPU offload backends)
+endif
+fypp_flags += -DOPENACC
+endif
+ifdef OPENMP
+fypp_flags += -DOPENMP
+endif
+
 ifeq (, $(shell which fypp))
 $(error "fypp not found. Check the readme, or pip install fypp.")
 endif

--- a/make/35-dependencies.mk
+++ b/make/35-dependencies.mk
@@ -11,12 +11,15 @@ endif
 ifdef OPENACC
   fortdepend_flags += -D_OPENACC
 endif
+ifdef OPENMP
+  fortdepend_flags += -D_OPENMP
+endif
 
 # make sure that config is read first
 ifdef CONFIG_READ
 $(build_dir)/dependencies.mk: $(f90_files) $(build_dir)/f90/agile.h | $(build_dir)
 	@echo "Regenerating dependencies"
-	@fortdepend $(fortdepend_flags) -f $(f90_files) -i mpi openacc -b $(build_dir)/obj -w -o $@
+	@fortdepend $(fortdepend_flags) -f $(f90_files) -i mpi openacc omp_lib -b $(build_dir)/obj -w -o $@
 
 # Precompiling and dependency tracking is not needed if we're cleaning.
 ifndef disable_precompile

--- a/src/agile.fpp
+++ b/src/agile.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> AMRVAC solves a set of hyperbolic equations
 !> \f$\vec{u}_t + \nabla_x \cdot \vec{f}(\vec{u}) = \vec{s}\f$
 !> using adaptive mesh refinement.
@@ -6,9 +7,15 @@ program agile
   integer        :: ierror
   ! Initialize MPI
   call MPI_INIT(ierror)
-  ! The OpenACC device must be set before any data is initialized on the GPU
+  ! The GPU device must be set before any data is initialized on the GPU
+#if defined(_OPENACC) && defined(_OPENMP)
+  error stop "Both OpenACC and OpenMP are enabled, this is not supported"
+#endif
 #ifdef _OPENACC
   call set_openacc_device()
+#endif
+#ifdef _OPENMP
+  call set_openmp_device()
 #endif
   call main()
 
@@ -33,6 +40,25 @@ contains
     call acc_set_device_num(my_device, dev_type)
 
   end subroutine set_openacc_device
+#endif
+
+#ifdef _OPENMP
+  subroutine set_openmp_device
+    use mpi
+    use omp_lib
+    integer :: local_rank, comm_shared, my_device, num_devices, ierror
+
+    call MPI_COMM_SPLIT_TYPE(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, comm_shared, ierror)
+    call MPI_COMM_RANK(comm_shared, local_rank, ierror)
+
+    num_devices = omp_get_num_devices()
+
+    if (num_devices < 1) error stop "No devices available on host"
+
+    my_device = mod(local_rank, num_devices)
+    call omp_set_default_device(my_device)
+
+  end subroutine set_openmp_device
 #endif
 
   subroutine main
@@ -69,7 +95,7 @@ contains
 
     time0 = MPI_WTIME()
     time_advance = .false.
-    !$acc update device(time_advance)
+    ${GPU_UPDATE_DEVICE('time_advance')}$
     time_bc      = zero
 
     ! read command line arguments first
@@ -289,7 +315,7 @@ contains
     dt_loop=0.d0
 
     time_advance=.true.
-    !$acc update device(time_advance)
+    ${GPU_UPDATE_DEVICE('time_advance')}$
 
     time_evol : do
 
@@ -421,7 +447,7 @@ contains
     end if
 
     time_advance=.false.
-    !$acc update device(time_advance)
+    ${GPU_UPDATE_DEVICE('time_advance')}$
 
     timeloop=MPI_WTIME()-timeloop0
 

--- a/src/agile.fpp
+++ b/src/agile.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> AMRVAC solves a set of hyperbolic equations
 !> \f$\vec{u}_t + \nabla_x \cdot \vec{f}(\vec{u}) = \vec{s}\f$
 !> using adaptive mesh refinement.

--- a/src/amr/mod_amr_solution_node.fpp
+++ b/src/amr/mod_amr_solution_node.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_amr_solution_node
   use mod_comm_lib, only: mpistop
 
@@ -41,9 +42,9 @@ contains
     if (ipe==mype) then
        ! initialize node on host and device
        node(1:nodehi,getnode) = 0
-       !$acc update device(node(1:nodehi,getnode))
+       ${GPU_UPDATE_DEVICE('node(1:nodehi,getnode)')}$
        rnode(1:rnodehi,getnode) = zero
-       !$acc update device(rnode(1:rnodehi,getnode))
+       ${GPU_UPDATE_DEVICE('rnode(1:rnodehi,getnode)')}$
     end if
   
   end function getnode
@@ -61,9 +62,9 @@ contains
   
   !> allocate arrays on igrid node
   subroutine alloc_node(igrid)
-#ifdef _OPENACC
-    use acc_utils
-#endif    
+#if defined(_OPENACC) || defined(_OPENMP)
+    use gpu_utils
+#endif
     use mod_forest
     use mod_global_parameters
     use mod_geometry
@@ -190,14 +191,14 @@ contains
     node(pig1_,igrid)=ig1
     node(pig2_,igrid)=ig2
     node(pig3_,igrid)=ig3
- !$acc update device(node(plevel_,igrid),node(pig1_,igrid),node(pig2_,igrid),node(pig3_,igrid))
+ ${GPU_UPDATE_DEVICE('node(plevel_,igrid),node(pig1_,igrid),node(pig2_,igrid),node(pig3_,igrid)')}$
     
     ! set dx information
     rnode(rpdx1_,igrid)=dx(1,level)
     rnode(rpdx2_,igrid)=dx(2,level)
     rnode(rpdx3_,igrid)=dx(3,level)
     dxlevel(:)=dx(:,level)
- !$acc update device(rnode(rpdx1_,igrid),rnode(rpdx2_,igrid),rnode(rpdx3_,igrid), dxlevel)
+ ${GPU_UPDATE_DEVICE('rnode(rpdx1_,igrid),rnode(rpdx2_,igrid),rnode(rpdx3_,igrid), dxlevel')}$
 
     ! uniform cartesian case as well as all unstretched coordinates
     ! determine the minimal and maximal corners
@@ -211,7 +212,7 @@ contains
    if(rnode(rpxmax2_,igrid)>xprobmax2) rnode(rpxmax2_,igrid)=xprobmax2
    if(rnode(rpxmax3_,igrid)>xprobmax3) rnode(rpxmax3_,igrid)=xprobmax3
 
- !$acc update device( rnode(rpxmax1_,igrid),rnode(rpxmax2_,igrid),rnode(rpxmax3_,igrid), rnode(rpxmin1_,igrid),rnode(rpxmin2_,igrid),rnode(rpxmin3_,igrid) )
+ ${GPU_UPDATE_DEVICE('rnode(rpxmax1_,igrid),rnode(rpxmax2_,igrid),rnode(rpxmax3_,igrid), rnode(rpxmin1_,igrid),rnode(rpxmin2_,igrid),rnode(rpxmin3_,igrid)')}$
    
     dx1=rnode(rpdx1_,igrid)
     dx2=rnode(rpdx2_,igrid)
@@ -1597,9 +1598,9 @@ contains
       phyboundblock(igrid)=.false.
    end if
 
-   !$acc update device( phyboundblock(igrid) )
-#ifdef _OPENACC
-   call copy_or_update(ps(igrid)%igrid) 
+   ${GPU_UPDATE_DEVICE('phyboundblock(igrid)')}$
+#if defined(_OPENACC) || defined(_OPENMP)
+   call copy_or_update(ps(igrid)%igrid)
    call copy_or_update(ps1(igrid)%igrid) 
    call copy_or_update(ps2(igrid)%igrid)
 

--- a/src/amr/mod_amr_solution_node.fpp
+++ b/src/amr/mod_amr_solution_node.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_amr_solution_node
   use mod_comm_lib, only: mpistop
 

--- a/src/amr/mod_coarsen.fpp
+++ b/src/amr/mod_coarsen.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_coarsen
   use mod_global_parameters
   use mod_physics

--- a/src/amr/mod_coarsen.fpp
+++ b/src/amr/mod_coarsen.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_coarsen
   use mod_global_parameters
   use mod_physics
@@ -36,9 +37,9 @@ contains
 
     if(slab_uniform) then
        CoFiratio=one/dble(2**ndim)
-       !$acc parallel loop gang
+       ${GPU_PARALLEL_LOOP_GANG()}$
        do iw=1,nw
-          !$acc loop collapse(3) vector
+          ${GPU_LOOP_VECTOR("collapse(3)")}$
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
@@ -52,9 +53,9 @@ contains
           end do
       end do
     else
-       !$acc parallel loop gang
+       ${GPU_PARALLEL_LOOP_GANG()}$
        do iw=1,nw
-          !$acc loop collapse(3) vector
+          ${GPU_LOOP_VECTOR("collapse(3)")}$
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1

--- a/src/amr/mod_coarsen.fpp
+++ b/src/amr/mod_coarsen.fpp
@@ -41,7 +41,7 @@ contains
        CoFiratio=one/dble(2**ndim)
        ${GPU_PARALLEL_LOOP_GANG()}$
        do iw=1,nw
-          ${GPU_LOOP_VECTOR("collapse(3)")}$
+          ${GPU_LOOP_VECTOR("collapse(3) private(ixFi1,ixFi2,ixFi3)")}$
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1
@@ -57,7 +57,7 @@ contains
     else
        ${GPU_PARALLEL_LOOP_GANG()}$
        do iw=1,nw
-          ${GPU_LOOP_VECTOR("collapse(3)")}$
+          ${GPU_LOOP_VECTOR("collapse(3) private(ixFi1,ixFi2,ixFi3)")}$
           do ixCo3 = ixComin3,ixComax3
              do ixCo2 = ixComin2,ixComax2
                 do ixCo1 = ixComin1,ixComax1

--- a/src/amr/mod_coarsen_refine.fpp
+++ b/src/amr/mod_coarsen_refine.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 !> Module to coarsen and refine grids for AMR
 module mod_coarsen_refine
 #ifdef USE_MPIWRAPPERS
@@ -15,10 +16,10 @@ module mod_coarsen_refine
   !> MPI buffers to send non-local coarsened grids
   double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff_cf, rcv_buff_cf
   integer, allocatable, dimension(:,:)  :: rcv_info_cf
-  !$acc declare create(snd_buff_cf,rcv_buff_cf,rcv_info_cf)
+  ${GPU_DECLARE_CREATE('snd_buff_cf,rcv_buff_cf,rcv_info_cf')}$
   !> maximum number of coarse blocks that can be sent after coarsening
   integer, parameter :: max_buff=1024
-  !$acc declare copyin(max_buff)
+  ${GPU_DECLARE_COPYIN('max_buff')}$
   !> MPI recv send variables for staggered-variable AMR
   integer :: itag_stg
   integer, dimension(:), allocatable :: recvrequest_stg, sendrequest_stg
@@ -85,7 +86,7 @@ contains
        allocate( snd_buff_cf(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
             rcv_buff_cf(block_nx1/2, block_nx2/2, block_nx3/2, nw, max_buff), &
             rcv_info_cf(4, max_buff) )
-       !$acc update device(snd_buff_cf, rcv_buff_cf, rcv_info_cf)
+       ${GPU_UPDATE_DEVICE('snd_buff_cf, rcv_buff_cf, rcv_info_cf')}$
     end if
 
     do ipe=0,npe-1
@@ -139,17 +140,17 @@ contains
 
     ! unpack the receive buffers on GPU
 #ifdef NOGPUDIRECT
-    !$acc update device(rcv_buff_cf(:,:,:,:,1:irecv))
+    ${GPU_UPDATE_DEVICE('rcv_buff_cf(:,:,:,:,1:irecv)')}$
 #endif
-    !$acc update device(rcv_info_cf(:,1:irecv))
+    ${GPU_UPDATE_DEVICE('rcv_info_cf(:,1:irecv)')}$
 
-    !$acc parallel loop gang
+    ${GPU_PARALLEL_LOOP_GANG()}$
     do ibuff = 1, irecv
        igrid = rcv_info_cf(1,ibuff)
        ic1   = rcv_info_cf(2,ibuff)
        ic2   = rcv_info_cf(3,ibuff)
        ic3   = rcv_info_cf(4,ibuff)
-       !$acc loop collapse(4) vector
+       ${GPU_LOOP_VECTOR("collapse(4)")}$
        do iw = 1, nw
           do ix3 = 1, block_nx3/2
              do ix2 = 1, block_nx2/2
@@ -246,7 +247,7 @@ contains
        call usr_after_refine(n_coarsen, n_refine)
     end if
 
-    !$acc update device(coarsen, refine)
+    ${GPU_UPDATE_DEVICE('coarsen, refine')}$
 
   end subroutine amr_coarsen_refine
 
@@ -501,9 +502,9 @@ contains
                    if (isend > max_buff) then
                       call mpistop('coarsen_grid_siblings: max_buff too small in send')
                    end if
-                   !$acc parallel loop gang
+                   ${GPU_PARALLEL_LOOP_GANG()}$
                    do iw = 1, nw
-                      !$acc loop collapse(3) vector
+                      ${GPU_LOOP_VECTOR("collapse(3)")}$
                       do ix3 = 1, block_nx3/2
                          do ix2 = 1, block_nx2/2
                             do ix1 = 1, block_nx1/2
@@ -515,15 +516,15 @@ contains
                    end do
 
 #ifndef NOGPUDIRECT
-                   !$acc host_data use_device(snd_buff_cf)
+                   ${GPU_HOST_DATA_USE_DEVICE('snd_buff_cf')}$
 #else
-                   !$acc update host(snd_buff_cf(:,:,:,:,isend))
+                   ${GPU_UPDATE_HOST('snd_buff_cf(:,:,:,:,isend)')}$
 #endif
                    call mpi_isend_wrapper(snd_buff_cf(:,:,:,:,isend), &
                         block_nx1*block_nx2*block_nx3/8*nw,MPI_DOUBLE_PRECISION,ipe,itag, icomm,&
                         sendrequest(isend),ierrmpi)
 #ifndef NOGPUDIRECT
-                   !$acc end host_data
+                   ${GPU_END_HOST_DATA()}$
 #endif
                    if(stagger_grid) then
                       do idir=1,ndim
@@ -542,13 +543,13 @@ contains
                       call mpistop('coarsen_grid_siblings: max_buff too small in receive')
                    end if
 #ifndef NOGPUDIRECT
-                   !$acc host_data use_device(rcv_buff_cf)
+                   ${GPU_HOST_DATA_USE_DEVICE('rcv_buff_cf')}$
 #endif
                    call mpi_irecv_wrapper(rcv_buff_cf(:,:,:,:,irecv), &
                         block_nx1*block_nx2*block_nx3/8*nw,MPI_DOUBLE_PRECISION,ipeFi, &
                         itag, icomm,recvrequest(irecv),ierrmpi)
 #ifndef NOGPUDIRECT
-                   !$acc end host_data
+                   ${GPU_END_HOST_DATA()}$
 #endif
                    rcv_info_cf(:,irecv) = [igrid, ic1, ic2, ic3]
                    if(stagger_grid) then

--- a/src/amr/mod_coarsen_refine.fpp
+++ b/src/amr/mod_coarsen_refine.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 !> Module to coarsen and refine grids for AMR
 module mod_coarsen_refine
 #ifdef USE_MPIWRAPPERS

--- a/src/amr/mod_coarsen_refine.fpp
+++ b/src/amr/mod_coarsen_refine.fpp
@@ -19,7 +19,6 @@ module mod_coarsen_refine
   ${GPU_DECLARE_CREATE('snd_buff_cf,rcv_buff_cf,rcv_info_cf')}$
   !> maximum number of coarse blocks that can be sent after coarsening
   integer, parameter :: max_buff=1024
-  ${GPU_DECLARE_COPYIN('max_buff')}$
   !> MPI recv send variables for staggered-variable AMR
   integer :: itag_stg
   integer, dimension(:), allocatable :: recvrequest_stg, sendrequest_stg

--- a/src/amr/mod_coarsen_refine.fpp
+++ b/src/amr/mod_coarsen_refine.fpp
@@ -145,7 +145,7 @@ contains
 #endif
     ${GPU_UPDATE_DEVICE('rcv_info_cf(:,1:irecv)')}$
 
-    ${GPU_PARALLEL_LOOP_GANG()}$
+    ${GPU_PARALLEL_LOOP_GANG("private(igrid, ic1, ic2, ic3)")}$
     do ibuff = 1, irecv
        igrid = rcv_info_cf(1,ibuff)
        ic1   = rcv_info_cf(2,ibuff)

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_errest
   use mod_comm_lib, only: mpistop
   implicit none
@@ -14,133 +15,130 @@ contains
 
     integer :: igrid, iigrid
 
-    if (igridstail==0) return
-
-    select case (refine_criterion)
-    case (1)
-       ! all refinement solely based on user routine usr_refine_grid
-    case (3)
-       ! Error estimation is based on Lohner's scheme
-       !$acc parallel loop gang private(igrid)
-       do iigrid=1,igridstail; igrid=igrids(iigrid);
-          call lohner_grid(igrid)
-       end do
-    case default
-       call mpistop("Unknown error estimator")
-    end select
-
-    if ( refine_usr ) then
-       !$acc parallel loop gang private(igrid)
-       do iigrid=1,igridstail; igrid=igrids(iigrid);
-          call forcedrefine_grid(igrid)
-       end do
-    end if
-
-    !$acc update host(refine, coarsen)
-
-  end subroutine errest
-
-  subroutine lohner_grid(igrid)
-    !$acc routine vector
-    use mod_forest, only: coarsen, refine
-    use mod_global_parameters
-
-    integer, intent(in) :: igrid
-
+    ! Locals inlined from lohner_grid (see comment below for why this is
+    ! inlined rather than a called GPU_ROUTINE_VECTOR subroutine)
     integer                            :: iflag, idims1, idims2, level
     integer                            :: ix1, ix2, ix3
     double precision                   :: threshold, error, numerator, denominator
     logical                            :: refineflag, coarsenflag
     double precision, parameter        :: epsilon=1.0d-6
 
-      level       = node(plevel_,igrid)
-      threshold   = refine_threshold(level)
+    if (igridstail==0) return
 
-      refineflag  = .false.
-      coarsenflag = .true.
-      !$acc loop vector collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag)
-      do ix3 = ixMlo3, ixMhi3
-         do ix2 = ixMlo2, ixMhi2
-            do ix1 = ixMlo1, ixMhi1
+    select case (refine_criterion)
+    case (1)
+       ! all refinement solely based on user routine usr_refine_grid
+    case (3)
+       ! Error estimation is based on Lohner's scheme.
+       ! Inlined version of lohner_igrid subroutine, because a vector-parallelism
+       ! subroutine called from a gang loop does not work with OpenMP.
+       ! Note: the same could happen to a user-defined refinement, but this has not yet been tested.
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid, level, threshold, refineflag, coarsenflag)")}$
+       do iigrid=1,igridstail; igrid=igrids(iigrid);
 
-               error = zero
-               !$acc loop seq reduction(+:error)
-               do iflag = 1, nw
-                  if(w_refine_weight(iflag)==0.d0) cycle
+          level       = node(plevel_,igrid)
+          threshold   = refine_threshold(level)
 
-                  numerator   = zero
-                  denominator = zero
-                  !$acc loop seq reduction(+:numerator, denominator)
-                  do idims1 = 1, ndim
-                     do idims2 = 1, ndim
+          refineflag  = .false.
+          coarsenflag = .true.
+          ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(ix1,ix2,ix3,error,iflag,idims1,idims2,numerator,denominator)")}$
+          do ix3 = ixMlo3, ixMhi3
+             do ix2 = ixMlo2, ixMhi2
+                do ix1 = ixMlo1, ixMhi1
 
-                        numerator = numerator + &
-                             ( &
-                             ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
-                             ix2+kr(2,idims2)+kr(2,idims1), &
-                             ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
-                             - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
-                             ix2-kr(2,idims2)+kr(2,idims1), &
-                             ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
-                             - &
-                             ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
-                             ix2+kr(2,idims2)-kr(2,idims1), &
-                             ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
-                             - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
-                             ix2-kr(2,idims2)-kr(2,idims1), &
-                             ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
-                             )**2
+                   error = zero
+                   ${GPU_LOOP_SEQ()}$
+                   do iflag = 1, nw
+                      if(w_refine_weight(iflag)==0.d0) cycle
 
-                        denominator = denominator + &
-                             ( &
-                             abs( &
-                             bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
-                             - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                             ) &
-                             + abs( &
-                             bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                             - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
-                             ) &
-                             + amr_wavefilter(level) * ( &
-                             ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
-                             ix2+kr(2,idims1)+kr(2,idims2), &
-                             ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
-                             + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
-                             ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
-                             + &
-                             ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
-                             ix2+kr(2,idims1)-kr(2,idims2), &
-                             ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
-                             + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
-                             ix2-kr(2,idims1)-kr(2,idims2), &
-                             ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
-                             ) &
-                             )**2
-                     end do
-                  end do
+                      numerator   = zero
+                      denominator = zero
+                      ${GPU_LOOP_SEQ()}$
+                      do idims1 = 1, ndim
+                         do idims2 = 1, ndim
 
-                  error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
+                            numerator = numerator + &
+                                 ( &
+                                 ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
+                                 ix2+kr(2,idims2)+kr(2,idims1), &
+                                 ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
+                                 - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
+                                 ix2-kr(2,idims2)+kr(2,idims1), &
+                                 ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
+                                 - &
+                                 ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
+                                 ix2+kr(2,idims2)-kr(2,idims1), &
+                                 ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
+                                 - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
+                                 ix2-kr(2,idims2)-kr(2,idims1), &
+                                 ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
+                                 )**2
 
-               end do
+                            denominator = denominator + &
+                                 ( &
+                                 abs( &
+                                 bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
+                                 - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                                 ) &
+                                 + abs( &
+                                 bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                                 - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
+                                 ) &
+                                 + amr_wavefilter(level) * ( &
+                                 ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
+                                 ix2+kr(2,idims1)+kr(2,idims2), &
+                                 ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
+                                 + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
+                                 ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
+                                 + &
+                                 ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
+                                 ix2+kr(2,idims1)-kr(2,idims2), &
+                                 ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
+                                 + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
+                                 ix2-kr(2,idims1)-kr(2,idims2), &
+                                 ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
+                                 ) &
+                                 )**2
+                         end do
+                      end do
 
-               if (error > threshold) then
-                  refineflag = .true.
-               end if
-               if (error > derefine_ratio(level) * threshold) then
-                  coarsenflag = .false.
-               end if
+                      error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
 
-            end do
-         end do
-      end do
+                   end do
 
-      if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
-      if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
+                   if (error > threshold) then
+                      refineflag = .true.
+                   end if
+                   if (error > derefine_ratio(level) * threshold) then
+                      coarsenflag = .false.
+                   end if
 
-  end subroutine lohner_grid
+                end do
+             end do
+          end do
+
+          if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
+          if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
+
+       end do
+    case default
+       call mpistop("Unknown error estimator")
+    end select
+
+    if ( refine_usr ) then
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
+       do iigrid=1,igridstail; igrid=igrids(iigrid);
+          call forcedrefine_grid(igrid)
+       end do
+    end if
+
+    ${GPU_UPDATE_HOST('refine, coarsen')}$
+
+  end subroutine errest
+
 
   subroutine forcedrefine_grid(igrid)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     #:if defined('REFINE_USR')
     use mod_usr, only: usr_refine_grid
     #:endif

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -17,111 +17,16 @@ contains
 
     integer :: igrid, iigrid
 
-    ! Locals inlined from lohner_grid (see comment below for why this is
-    ! inlined rather than a called GPU_ROUTINE_VECTOR subroutine)
-    integer                            :: iflag, idims1, idims2, level
-    integer                            :: ix1, ix2, ix3
-    double precision                   :: threshold, error, numerator, denominator
-    logical                            :: refineflag, coarsenflag
-    double precision, parameter        :: epsilon=1.0d-6
-
     if (igridstail==0) return
 
     select case (refine_criterion)
     case (1)
        ! all refinement solely based on user routine usr_refine_grid
     case (3)
-       ! Error estimation is based on Lohner's scheme.
-       ! Inlined version of lohner_igrid subroutine, because a vector-parallelism
-       ! subroutine called from a gang loop does not work with OpenMP.
-       ! Note: the same could happen to a user-defined refinement, but this has not yet been tested.
-       ${GPU_PARALLEL_LOOP_GANG("private(igrid, level, threshold, refineflag, coarsenflag)")}$
+       ! Error estimation is based on Lohner's scheme
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
        do iigrid=1,igridstail; igrid=igrids(iigrid);
-
-          level       = node(plevel_,igrid)
-          threshold   = refine_threshold(level)
-
-          refineflag  = .false.
-          coarsenflag = .true.
-          ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(ix1,ix2,ix3,error,iflag,idims1,idims2,numerator,denominator)")}$
-          do ix3 = ixMlo3, ixMhi3
-             do ix2 = ixMlo2, ixMhi2
-                do ix1 = ixMlo1, ixMhi1
-
-                   error = zero
-                   ${GPU_LOOP_SEQ()}$
-                   do iflag = 1, nw
-                      if(w_refine_weight(iflag)==0.d0) cycle
-
-                      numerator   = zero
-                      denominator = zero
-                      ${GPU_LOOP_SEQ()}$
-                      do idims1 = 1, ndim
-                         do idims2 = 1, ndim
-
-                            numerator = numerator + &
-                                 ( &
-                                 ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
-                                 ix2+kr(2,idims2)+kr(2,idims1), &
-                                 ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
-                                 - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
-                                 ix2-kr(2,idims2)+kr(2,idims1), &
-                                 ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
-                                 - &
-                                 ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
-                                 ix2+kr(2,idims2)-kr(2,idims1), &
-                                 ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
-                                 - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
-                                 ix2-kr(2,idims2)-kr(2,idims1), &
-                                 ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
-                                 )**2
-
-                            denominator = denominator + &
-                                 ( &
-                                 abs( &
-                                 bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
-                                 - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                                 ) &
-                                 + abs( &
-                                 bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                                 - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
-                                 ) &
-                                 + amr_wavefilter(level) * ( &
-                                 ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
-                                 ix2+kr(2,idims1)+kr(2,idims2), &
-                                 ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
-                                 + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
-                                 ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
-                                 + &
-                                 ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
-                                 ix2+kr(2,idims1)-kr(2,idims2), &
-                                 ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
-                                 + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
-                                 ix2-kr(2,idims1)-kr(2,idims2), &
-                                 ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
-                                 ) &
-                                 )**2
-                         end do
-                      end do
-
-                      error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
-
-                   end do
-
-                   if (error > threshold) then
-                      refineflag = .true.
-                   end if
-                   if (error > derefine_ratio(level) * threshold) then
-                      coarsenflag = .false.
-                   end if
-
-                end do
-             end do
-          end do
-
-          if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
-          if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
-
+          call lohner_grid(igrid)
        end do
     case default
        call mpistop("Unknown error estimator")
@@ -134,10 +39,97 @@ contains
        end do
     end if
 
-    ${GPU_UPDATE_HOST('refine, coarsen')}$
+    ${GPU_UPDATE_HOST("refine, coarsen")}$
 
   end subroutine errest
 
+  subroutine lohner_grid(igrid)
+    use mod_forest, only: coarsen, refine
+    use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
+
+    integer, intent(in) :: igrid
+
+    integer                            :: iflag, idims1, idims2, level
+    integer                            :: ix1, ix2, ix3
+    double precision                   :: threshold, error, numerator, denominator
+    logical                            :: refineflag, coarsenflag
+    double precision, parameter        :: epsilon=1.0d-6
+
+      level       = node(plevel_,igrid)
+      threshold   = refine_threshold(level)
+      refineflag  = .false.
+      coarsenflag = .true.
+      ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(error,numerator,denominator)")}$
+      do ix3 = ixMlo3, ixMhi3
+         do ix2 = ixMlo2, ixMhi2
+            do ix1 = ixMlo1, ixMhi1
+               error = zero
+               ${GPU_LOOP_SEQ()}$
+               do iflag = 1, nw
+                  if(w_refine_weight(iflag)==0.d0) cycle
+                  numerator   = zero
+                  denominator = zero
+                  ${GPU_LOOP_SEQ()}$
+                  do idims1 = 1, ndim
+                     do idims2 = 1, ndim
+                        numerator = numerator + &
+                             ( &
+                             ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
+                             ix2+kr(2,idims2)+kr(2,idims1), &
+                             ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
+                             - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
+                             ix2-kr(2,idims2)+kr(2,idims1), &
+                             ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
+                             - &
+                             ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
+                             ix2+kr(2,idims2)-kr(2,idims1), &
+                             ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
+                             - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
+                             ix2-kr(2,idims2)-kr(2,idims1), &
+                             ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
+                             )**2
+                        denominator = denominator + &
+                             ( &
+                             abs( &
+                             bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
+                             - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                             ) &
+                             + abs( &
+                             bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                             - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
+                             ) &
+                             + amr_wavefilter(level) * ( &
+                             ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
+                             ix2+kr(2,idims1)+kr(2,idims2), &
+                             ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
+                             + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
+                             ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
+                             + &
+                             ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
+                             ix2+kr(2,idims1)-kr(2,idims2), &
+                             ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
+                             + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
+                             ix2-kr(2,idims1)-kr(2,idims2), &
+                             ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
+                             ) &
+                             )**2
+                     end do
+                  end do
+                  error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
+               end do
+               if (error > threshold) then
+                  refineflag = .true.
+               end if
+               if (error > derefine_ratio(level) * threshold) then
+                  coarsenflag = .false.
+               end if
+            end do
+         end do
+      end do
+      if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
+      if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
+  end subroutine lohner_grid
 
   subroutine forcedrefine_grid(igrid)
     #:if defined('REFINE_USR')

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -10,141 +10,101 @@ module mod_errest
 
 contains
 
-  !> Do all local error estimation which determines (de)refinement
-  subroutine errest
-    use mod_forest, only: refine, buffer, coarsen
-    use mod_global_parameters
+#:def lohner_grid_header()
+  integer                            :: iflag, idims1, idims2, level
+  integer                            :: ix1, ix2, ix3
+  double precision                   :: threshold, error, numerator, denominator
+  logical                            :: refineflag, coarsenflag
+  double precision, parameter        :: epsilon=1.0d-6
+#:enddef
 
-    integer :: igrid, iigrid
+#:def lohner_grid()
+  level       = node(plevel_,igrid)
+  threshold   = refine_threshold(level)
+  refineflag  = .false.
+  coarsenflag = .true.
+  ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(error,numerator,denominator)")}$
+  do ix3 = ixMlo3, ixMhi3
+     do ix2 = ixMlo2, ixMhi2
+        do ix1 = ixMlo1, ixMhi1
+           error = zero
+           ${GPU_LOOP_SEQ()}$
+           do iflag = 1, nw
+              if(w_refine_weight(iflag)==0.d0) cycle
+              numerator   = zero
+              denominator = zero
+              ${GPU_LOOP_SEQ()}$
+              do idims1 = 1, ndim
+                 do idims2 = 1, ndim
+                    numerator = numerator + &
+                          ( &
+                          ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
+                          ix2+kr(2,idims2)+kr(2,idims1), &
+                          ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
+                          - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
+                          ix2-kr(2,idims2)+kr(2,idims1), &
+                          ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
+                          - &
+                          ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
+                          ix2+kr(2,idims2)-kr(2,idims1), &
+                          ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
+                          - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
+                          ix2-kr(2,idims2)-kr(2,idims1), &
+                          ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
+                          )**2
+                    denominator = denominator + &
+                          ( &
+                          abs( &
+                          bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
+                          - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                          ) &
+                          + abs( &
+                          bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
+                          - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
+                          ) &
+                          + amr_wavefilter(level) * ( &
+                          ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
+                          ix2+kr(2,idims1)+kr(2,idims2), &
+                          ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
+                          + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
+                          ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
+                          + &
+                          ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
+                          ix2+kr(2,idims1)-kr(2,idims2), &
+                          ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
+                          + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
+                          ix2-kr(2,idims1)-kr(2,idims2), &
+                          ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
+                          ) &
+                          )**2
+                 end do
+              end do
+              error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
+           end do
+           if (error > threshold) then
+              refineflag = .true.
+           end if
+           if (error > derefine_ratio(level) * threshold) then
+              coarsenflag = .false.
+           end if
+        end do
+     end do
+  end do
+  if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
+  if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
+#:enddef
 
-    if (igridstail==0) return
-
-    select case (refine_criterion)
-    case (1)
-       ! all refinement solely based on user routine usr_refine_grid
-    case (3)
-       ! Error estimation is based on Lohner's scheme
-       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
-       do iigrid=1,igridstail; igrid=igrids(iigrid);
-          call lohner_grid(igrid)
-       end do
-    case default
-       call mpistop("Unknown error estimator")
-    end select
-
-    if ( refine_usr ) then
-       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
-       do iigrid=1,igridstail; igrid=igrids(iigrid);
-          call forcedrefine_grid(igrid)
-       end do
-    end if
-
-    ${GPU_UPDATE_HOST("refine, coarsen")}$
-
-  end subroutine errest
-
-  subroutine lohner_grid(igrid)
-    use mod_forest, only: coarsen, refine
-    use mod_global_parameters
-    ${GPU_ROUTINE_VECTOR()}$
-
-    integer, intent(in) :: igrid
-
-    integer                            :: iflag, idims1, idims2, level
-    integer                            :: ix1, ix2, ix3
-    double precision                   :: threshold, error, numerator, denominator
-    logical                            :: refineflag, coarsenflag
-    double precision, parameter        :: epsilon=1.0d-6
-
-      level       = node(plevel_,igrid)
-      threshold   = refine_threshold(level)
-      refineflag  = .false.
-      coarsenflag = .true.
-      ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(error,numerator,denominator)")}$
-      do ix3 = ixMlo3, ixMhi3
-         do ix2 = ixMlo2, ixMhi2
-            do ix1 = ixMlo1, ixMhi1
-               error = zero
-               ${GPU_LOOP_SEQ()}$
-               do iflag = 1, nw
-                  if(w_refine_weight(iflag)==0.d0) cycle
-                  numerator   = zero
-                  denominator = zero
-                  ${GPU_LOOP_SEQ()}$
-                  do idims1 = 1, ndim
-                     do idims2 = 1, ndim
-                        numerator = numerator + &
-                             ( &
-                             ( bg(1)%w(ix1+kr(1,idims2)+kr(1,idims1), &
-                             ix2+kr(2,idims2)+kr(2,idims1), &
-                             ix3+kr(3,idims2)+kr(3,idims1), iflag, igrid)    &
-                             - bg(1)%w(ix1-kr(1,idims2)+kr(1,idims1), &
-                             ix2-kr(2,idims2)+kr(2,idims1), &
-                             ix3-kr(3,idims2)+kr(3,idims1), iflag, igrid) )  &
-                             - &
-                             ( bg(1)%w(ix1+kr(1,idims2)-kr(1,idims1), &
-                             ix2+kr(2,idims2)-kr(2,idims1), &
-                             ix3+kr(3,idims2)-kr(3,idims1), iflag, igrid)    &
-                             - bg(1)%w(ix1-kr(1,idims2)-kr(1,idims1), &
-                             ix2-kr(2,idims2)-kr(2,idims1), &
-                             ix3-kr(3,idims2)-kr(3,idims1), iflag, igrid) )  &
-                             )**2
-                        denominator = denominator + &
-                             ( &
-                             abs( &
-                             bg(1)%w(ix1+2*kr(1,idims1), ix2+2*kr(2,idims1), ix3+2*kr(3,idims1), iflag, igrid) &
-                             - bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                             ) &
-                             + abs( &
-                             bg(1)%w(ix1, ix2, ix3, iflag, igrid) &
-                             - bg(1)%w(ix1-2*kr(1,idims1), ix2-2*kr(2,idims1), ix3-2*kr(3,idims1), iflag, igrid) &
-                             ) &
-                             + amr_wavefilter(level) * ( &
-                             ( abs( bg(1)%w(ix1+kr(1,idims1)+kr(1,idims2), &
-                             ix2+kr(2,idims1)+kr(2,idims2), &
-                             ix3+kr(3,idims1)+kr(3,idims2), iflag, igrid) )   &
-                             + abs( bg(1)%w(ix1-kr(1,idims1)+kr(1,idims2), &
-                             ix2-kr(2,idims1)+kr(2,idims2), ix3-kr(3,idims1)+kr(3,idims2), iflag, igrid) ) ) &
-                             + &
-                             ( abs( bg(1)%w(ix1+kr(1,idims1)-kr(1,idims2), &
-                             ix2+kr(2,idims1)-kr(2,idims2), &
-                             ix3+kr(3,idims1)-kr(3,idims2), iflag, igrid) )   &
-                             + abs( bg(1)%w(ix1-kr(1,idims1)-kr(1,idims2), &
-                             ix2-kr(2,idims1)-kr(2,idims2), &
-                             ix3-kr(3,idims1)-kr(3,idims2), iflag, igrid) ) ) &
-                             ) &
-                             )**2
-                     end do
-                  end do
-                  error = error + w_refine_weight(iflag) * sqrt( numerator / max( denominator, epsilon ) )
-               end do
-               if (error > threshold) then
-                  refineflag = .true.
-               end if
-               if (error > derefine_ratio(level) * threshold) then
-                  coarsenflag = .false.
-               end if
-            end do
-         end do
-      end do
-      if (refineflag .and. level < refine_max_level) refine(igrid,mype)=.true.
-      if (coarsenflag .and. level > 1) coarsen(igrid,mype)=.true.
-  end subroutine lohner_grid
-
-  subroutine forcedrefine_grid(igrid)
+#:def forcedrefine_grid_header()
     #:if defined('REFINE_USR')
     use mod_usr, only: usr_refine_grid
     #:endif
-    use mod_forest, only: coarsen, refine, buffer
-    use mod_global_parameters
-    ${GPU_ROUTINE_VECTOR()}$
-
-    integer, intent(in) :: igrid
 
     integer :: level
     integer :: my_refine, my_coarsen
     double precision :: qt
+#:enddef
 
+#:def forcedrefine_grid()
     level=node(plevel_,igrid)
 
     ! initialize to 0
@@ -192,7 +152,46 @@ contains
       refine(igrid,mype)=.false.
     end if
 
-  end subroutine forcedrefine_grid
+#:enddef
+
+  !> Do all local error estimation which determines (de)refinement
+  subroutine errest
+    use mod_forest, only: refine, buffer, coarsen
+    use mod_global_parameters
+
+    integer :: igrid, iigrid
+
+    if (igridstail==0) return
+
+    select case (refine_criterion)
+    case (1)
+       ! all refinement solely based on user routine usr_refine_grid
+    case (3)
+       ! Error estimation is based on Lohner's scheme
+       block
+          @:lohner_grid_header()
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
+          do iigrid=1,igridstail; igrid=igrids(iigrid);
+             @:lohner_grid()
+          end do
+       end block
+    case default
+       call mpistop("Unknown error estimator")
+    end select
+
+    if ( refine_usr ) then
+       block
+          @:forcedrefine_grid_header()
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
+          do iigrid=1,igridstail; igrid=igrids(iigrid);
+             @:forcedrefine_grid()
+          end do
+       end block
+    end if
+
+    ${GPU_UPDATE_HOST("refine, coarsen")}$
+
+  end subroutine errest
 
   subroutine forcedrefine_grid_io(igrid,w)
     use mod_forest, only: coarsen, refine

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -138,12 +138,12 @@ contains
 
 
   subroutine forcedrefine_grid(igrid)
-    ${GPU_ROUTINE_VECTOR()}$
     #:if defined('REFINE_USR')
     use mod_usr, only: usr_refine_grid
     #:endif
     use mod_forest, only: coarsen, refine, buffer
     use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
 
     integer, intent(in) :: igrid
 

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_errest
   use mod_comm_lib, only: mpistop
   implicit none

--- a/src/amr/mod_errest.fpp
+++ b/src/amr/mod_errest.fpp
@@ -23,7 +23,7 @@ contains
   threshold   = refine_threshold(level)
   refineflag  = .false.
   coarsenflag = .true.
-  ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(error,numerator,denominator)")}$
+  ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:refineflag) reduction(.and.:coarsenflag) private(error,numerator,denominator,iflag,idims1,idims2)")}$
   do ix3 = ixMlo3, ixMhi3
      do ix2 = ixMlo2, ixMhi2
         do ix1 = ixMlo1, ixMhi1
@@ -170,7 +170,7 @@ contains
        ! Error estimation is based on Lohner's scheme
        block
           @:lohner_grid_header()
-          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid, level, threshold, refineflag, coarsenflag)")}$
           do iigrid=1,igridstail; igrid=igrids(iigrid);
              @:lohner_grid()
           end do
@@ -182,7 +182,7 @@ contains
     if ( refine_usr ) then
        block
           @:forcedrefine_grid_header()
-          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid, level, my_refine, my_coarsen, qt)")}$
           do iigrid=1,igridstail; igrid=igrids(iigrid);
              @:forcedrefine_grid()
           end do

--- a/src/amr/mod_forest.fpp
+++ b/src/amr/mod_forest.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 !> Module with basic grid data structures
 module mod_forest
    implicit none

--- a/src/amr/mod_forest.fpp
+++ b/src/amr/mod_forest.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 !> Module with basic grid data structures
 module mod_forest
    implicit none
@@ -70,7 +71,7 @@ module mod_forest
    !> AMR flags and grids-in-use identifier per processor (igrid,ipe) 
    logical, dimension(:,:), allocatable, save :: coarsen, refine, buffer,&
         igrid_inuse
-   !$acc declare create(coarsen, refine, buffer, igrid_inuse)
+   ${GPU_DECLARE_CREATE('coarsen, refine, buffer, igrid_inuse')}$
 
    !> Number of parent blocks
    integer, save :: nparents

--- a/src/amr/mod_initialize_amr.fpp
+++ b/src/amr/mod_initialize_amr.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_initialize_amr
 
   implicit none

--- a/src/amr/mod_initialize_amr.fpp
+++ b/src/amr/mod_initialize_amr.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_initialize_amr
 
   implicit none
@@ -69,7 +70,7 @@ contains
               ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,ps(igrid)%w,ps(igrid)%x)
       end if
       
-      !$acc update device(bg(1)%w(:,:,:,:,igrid))
+      ${GPU_UPDATE_DEVICE('bg(1)%w(:,:,:,:,igrid)')}$
     end subroutine initial_condition
 
     !> modify initial condition
@@ -92,7 +93,7 @@ contains
              ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,ps(igrid)%w,&
              ps(igrid)%x)
        end if
-       !$acc update device(bg(1)%w(:,:,:,:,igrid))
+       ${GPU_UPDATE_DEVICE('bg(1)%w(:,:,:,:,igrid)')}$
     end do
   
   end subroutine modify_IC

--- a/src/amr/mod_load_balance.fpp
+++ b/src/amr/mod_load_balance.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_load_balance
 #ifdef USE_MPIWRAPPERS
   use mod_mpi_wrapper

--- a/src/amr/mod_load_balance.fpp
+++ b/src/amr/mod_load_balance.fpp
@@ -116,7 +116,7 @@ contains
    ${GPU_UPDATE_DEVICE('rcv_buff_lb(:,:,:,:,1:irecv)')}$
 #endif
     ${GPU_UPDATE_DEVICE('rcv_info_lb(1:irecv)')}$
-    ${GPU_PARALLEL_LOOP_GANG()}$
+    ${GPU_PARALLEL_LOOP_GANG("private(recv_igrid)")}$
     do ibuff = 1, irecv
        recv_igrid = rcv_info_lb(ibuff)
        ${GPU_LOOP_VECTOR("collapse(4)")}$

--- a/src/amr/mod_load_balance.fpp
+++ b/src/amr/mod_load_balance.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_load_balance
 #ifdef USE_MPIWRAPPERS
   use mod_mpi_wrapper
@@ -16,7 +17,7 @@ module mod_load_balance
   !> MPI buffers to send blocks
   double precision, allocatable, dimension(:,:,:,:,:)  :: snd_buff_lb, rcv_buff_lb
   integer, allocatable, dimension(:)  :: rcv_info_lb
-  !$acc declare create(snd_buff_lb,rcv_buff_lb,rcv_info_lb)
+  ${GPU_DECLARE_CREATE('snd_buff_lb,rcv_buff_lb,rcv_info_lb')}$
   !> maximum number of blocks to send
   integer, parameter :: max_buff=1024
 
@@ -67,7 +68,7 @@ contains
        allocate( snd_buff_lb(block_nx1, block_nx2, block_nx3, nw, max_buff), &
             rcv_buff_lb(block_nx1, block_nx2, block_nx3, nw, max_buff), &
             rcv_info_lb(max_buff) )
-       !$acc update device(snd_buff_lb, rcv_buff_lb, rcv_info_lb)
+       ${GPU_UPDATE_DEVICE('snd_buff_lb, rcv_buff_lb, rcv_info_lb')}$
     end if
 
     do ipe=0,npe-1; do Morton_no=Morton_start(ipe),Morton_stop(ipe)
@@ -108,13 +109,13 @@ contains
 
     ! unpack the receive buffers on GPU
 #ifdef NOGPUDIRECT
-   !$acc update device(rcv_buff_lb(:,:,:,:,1:irecv))
+   ${GPU_UPDATE_DEVICE('rcv_buff_lb(:,:,:,:,1:irecv)')}$
 #endif
-    !$acc update device(rcv_info_lb(1:irecv))
-    !$acc parallel loop gang
+    ${GPU_UPDATE_DEVICE('rcv_info_lb(1:irecv)')}$
+    ${GPU_PARALLEL_LOOP_GANG()}$
     do ibuff = 1, irecv
        recv_igrid = rcv_info_lb(ibuff)
-       !$acc loop collapse(4) vector
+       ${GPU_LOOP_VECTOR("collapse(4)")}$
        do iw = 1, nw
           do ix3 = 1, block_nx3
              do ix2 = 1, block_nx2
@@ -163,14 +164,14 @@ contains
        call mpistop('load_balance: max_buff too small in receive')
     end if
 #ifndef NOGPUDIRECT
-    !$acc host_data use_device(rcv_buff_lb)
+    ${GPU_HOST_DATA_USE_DEVICE('rcv_buff_lb')}$
 #endif
     call mpi_irecv_wrapper(rcv_buff_lb(:,:,:,:,irecv), &
                    block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
           send_ipe,itag, icomm, &
           recvrequest(irecv),ierrmpi)
 #ifndef NOGPUDIRECT
-    !$acc end host_data
+    ${GPU_END_HOST_DATA()}$
 #endif
     rcv_info_lb(irecv) = recv_igrid
     if(stagger_grid) then
@@ -191,9 +192,9 @@ contains
     if (isend > max_buff) then
        call mpistop('load_balance: max_buff too small in send')
     end if
-    !$acc parallel loop gang default(present)
+    ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
     do iw = 1, nw
-       !$acc loop collapse(3) vector
+       ${GPU_LOOP_VECTOR("collapse(3)")}$
        do ix3 = 1, block_nx3
           do ix2 = 1, block_nx2
              do ix1 = 1, block_nx1
@@ -205,15 +206,15 @@ contains
     end do
 
 #ifndef NOGPUDIRECT
-    !$acc host_data use_device(snd_buff_lb)
+    ${GPU_HOST_DATA_USE_DEVICE('snd_buff_lb')}$
 #else
-    !$acc update host(snd_buff_lb(:,:,:,:,isend))
+    ${GPU_UPDATE_HOST('snd_buff_lb(:,:,:,:,isend)')}$
 #endif
     call mpi_isend_wrapper(snd_buff_lb(:,:,:,:,isend), &
                    block_nx1*block_nx2*block_nx3*nw, MPI_DOUBLE_PRECISION, &
           recv_ipe,itag, icomm, sendrequest(isend),ierrmpi)
 #ifndef NOGPUDIRECT
-    !$acc end host_data
+    ${GPU_END_HOST_DATA()}$
 #endif
     if(stagger_grid) then
        itag=recv_igrid+max_blocks

--- a/src/amr/mod_refine.fpp
+++ b/src/amr/mod_refine.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_refine
 
   implicit none
@@ -136,7 +137,7 @@ contains
     ixCgmin1=ixComin1;ixCgmin2=ixComin2;ixCgmin3=ixComin3;ixCgmax1=ixComax1
     ixCgmax2=ixComax2;ixCgmax3=ixComax3;
 
-    !$acc parallel loop collapse(3) private(slope)
+    ${GPU_PARALLEL_LOOP("collapse(3) private(slope)")}$
     do ixCo3 = ixCgmin3,ixCgmax3
        do ixCo2 = ixCgmin2,ixCgmax2
           do ixCo1 = ixCgmin1,ixCgmax1
@@ -251,7 +252,7 @@ contains
     integer :: ixCo1,ixCo2,ixCo3, ixFi1,ixFi2,ixFi3, iw
     integer :: ixFimin1,ixFimin2,ixFimin3,ixFimax1,ixFimax2,ixFimax3
 
-    !$acc parallel loop collapse(3)
+    ${GPU_PARALLEL_LOOP("collapse(3)")}$
     do ixCo3 = ixComin3,ixComax3
        do ixCo2 = ixComin2,ixComax2
           do ixCo1 = ixComin1,ixComax1

--- a/src/amr/mod_refine.fpp
+++ b/src/amr/mod_refine.fpp
@@ -117,7 +117,7 @@ contains
   subroutine prolong_2nd(sCo,ixComin1,ixComin2,ixComin3,ixComax1,ixComax2,&
      ixComax3,sFi,dxCo1,dxCo2,dxCo3,xComin1,xComin2,xComin3,dxFi1,dxFi2,dxFi3,&
      xFimin1,xFimin2,xFimin3,igridCo,igridFi)
-    use mod_physics, only: phys_to_conserved, phys_handle_small_values
+    use mod_physics, only: phys_to_conserved, phys_handle_small_values, nw_phys
     use mod_global_parameters
     use mod_amr_fct, only: already_fine, prolong_2nd_stg
 
@@ -132,7 +132,7 @@ contains
        ixFi2,ixFi3, ix1,ix2,ix3, idim, iw, ixCgmin1,ixCgmin2,ixCgmin3,ixCgmax1,&
        ixCgmax2,ixCgmax3, el
     double precision :: slopeL, slopeR, slopeC, signC, signR
-    double precision :: slope(nw,ndim)
+    double precision :: slope(nw_phys,ndim)
     double precision :: eta1,eta2,eta3
     logical :: fine_min1,fine_min2,fine_min3,fine_max1,fine_max2,fine_max3
 

--- a/src/amr/mod_refine.fpp
+++ b/src/amr/mod_refine.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_refine
 
   implicit none

--- a/src/amr/mod_refine.fpp
+++ b/src/amr/mod_refine.fpp
@@ -139,7 +139,7 @@ contains
     ixCgmin1=ixComin1;ixCgmin2=ixComin2;ixCgmin3=ixComin3;ixCgmax1=ixComax1
     ixCgmax2=ixComax2;ixCgmax3=ixComax3;
 
-    ${GPU_PARALLEL_LOOP("collapse(3) private(slope)")}$
+    ${GPU_PARALLEL_LOOP("collapse(3) private(slope, ixFi1,ixFi2,ixFi3, idim, hxCo1,hxCo2,hxCo3, jxCo1,jxCo2,jxCo3, iw, slopeL,slopeR,slopeC,signC,signR, ix1,ix2,ix3, eta1,eta2,eta3)")}$
     do ixCo3 = ixCgmin3,ixCgmax3
        do ixCo2 = ixCgmin2,ixCgmax2
           do ixCo1 = ixCgmin1,ixCgmax1
@@ -254,7 +254,7 @@ contains
     integer :: ixCo1,ixCo2,ixCo3, ixFi1,ixFi2,ixFi3, iw
     integer :: ixFimin1,ixFimin2,ixFimin3,ixFimax1,ixFimax2,ixFimax3
 
-    ${GPU_PARALLEL_LOOP("collapse(3)")}$
+    ${GPU_PARALLEL_LOOP("collapse(3) private(ixFi1,ixFi2,ixFi3,iw)")}$
     do ixCo3 = ixComin3,ixComax3
        do ixCo2 = ixComin2,ixComax2
           do ixCo1 = ixComin1,ixComax1

--- a/src/amr/mod_selectgrids.fpp
+++ b/src/amr/mod_selectgrids.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_selectgrids
 
   implicit none
@@ -50,7 +51,7 @@ contains
   
   !     Check if user wants to deactivate grids at all and return if not:
         if (userflag == -1) then
- !$acc update device(igrids_active, igrids_passive, igridstail_active, igridstail_passive)
+           ${GPU_UPDATE_DEVICE('igrids_active, igrids_passive, igridstail_active, igridstail_passive')}$
            return
         end if
   
@@ -110,7 +111,7 @@ contains
            end do
         end do
 
- !$acc update device(igrids_active, igrids_passive, igridstail_active, igridstail_passive)
+   ${GPU_UPDATE_DEVICE('igrids_active, igrids_passive, igridstail_active, igridstail_passive')}$
         
         contains
   !=============================================================================

--- a/src/amr/mod_selectgrids.fpp
+++ b/src/amr/mod_selectgrids.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_selectgrids
 
   implicit none

--- a/src/ffhd/mod_ffhd_templates.fpp
+++ b/src/ffhd/mod_ffhd_templates.fpp
@@ -1,5 +1,6 @@
+#:include "../mod_gpu_directives.fpp"
 #:if PHYS == 'ffhd'
-  
+
 #:def phys_vars()
 
   integer, parameter :: dp = kind(0.0d0)
@@ -24,75 +25,75 @@
 
   !> Whether an energy equation is used
   logical, public                         :: ffhd_energy = .true.
-  !$acc declare copyin(ffhd_energy)
+  ${GPU_DECLARE_COPYIN('ffhd_energy')}$
 
   !> Index of the density (in the w array)
   integer, public                         :: rho_
-  !$acc declare create(rho_)
+  ${GPU_DECLARE_CREATE('rho_')}$
 
   !> Indices of the momentum density
   integer, allocatable, public            :: mom(:)
-  !$acc declare create(mom)
+  ${GPU_DECLARE_CREATE('mom')}$
 
   !> Index of the energy density (-1 if not present)
   integer, public                         :: e_
-  !$acc declare create(e_)
+  ${GPU_DECLARE_CREATE('e_')}$
 
   !> Index of the gas pressure (-1 if not present) should equal e_
   integer, public                         :: p_
-  !$acc declare create(p_)
+  ${GPU_DECLARE_CREATE('p_')}$
 
   !> Index of the hyperbolic flux variable
   integer, public                         :: q_
-  !$acc declare create(q_)
+  ${GPU_DECLARE_CREATE('q_')}$
 
   ! !> Index of the frozen magnetic field
   integer, public                         :: iw_b1
   integer, public                         :: iw_b2
   integer, public                         :: iw_b3
-  !$acc declare create(iw_b1, iw_b2, iw_b3)
+  ${GPU_DECLARE_CREATE('iw_b1, iw_b2, iw_b3')}$
 
   !> The adiabatic index
   double precision, public                :: ffhd_gamma = 5.d0/3.0d0
   double precision, public                :: gamma_1, inv_gamma_1
-  !$acc declare copyin(ffhd_gamma, gamma_1, inv_gamma_1)
-  !$acc declare create(gamma_1, inv_gamma_1)
+  ${GPU_DECLARE_COPYIN('ffhd_gamma, gamma_1, inv_gamma_1')}$
+  ${GPU_DECLARE_CREATE('gamma_1, inv_gamma_1')}$
 
   !> The adiabatic constant
   double precision, public                :: ffhd_adiab = 1.0d0
-  !$acc declare copyin(ffhd_adiab)
+  ${GPU_DECLARE_COPYIN('ffhd_adiab')}$
 
   !> The helium abundance
   double precision, public                :: He_abundance=0.1d0
-  !$acc declare copyin(He_abundance)
+  ${GPU_DECLARE_COPYIN('He_abundance')}$
 
   !> The thermal conductivity kappa in hyperbolic thermal conduction
   double precision, public                :: hypertc_kappa=-1.0d0
-  !$acc declare copyin(hypertc_kappa)
+  ${GPU_DECLARE_COPYIN('hypertc_kappa')}$
 
   !> Whether p*divb source term is not zero
   logical, public                         :: ffhd_pdivb = .false.
-  !$acc declare copyin(ffhd_pdivb)
+  ${GPU_DECLARE_COPYIN('ffhd_pdivb')}$
 
   !> switch for hyperbolic thermal conduction
   logical, public                         :: ffhd_hyperbolic_thermal_conduction = .false.
-  !$acc declare copyin(ffhd_hyperbolic_thermal_conduction)
+  ${GPU_DECLARE_COPYIN('ffhd_hyperbolic_thermal_conduction')}$
 
   !> Whether plasma is partially ionized
   logical, public                         :: ffhd_partial_ionization = .false.
-  !$acc declare copyin(ffhd_partial_ionization)
+  ${GPU_DECLARE_COPYIN('ffhd_partial_ionization')}$
 
   !> switch for gravity
   logical, public                         :: ffhd_gravity = .false.
-  !$acc declare copyin(ffhd_gravity)
+  ${GPU_DECLARE_COPYIN('ffhd_gravity')}$
 
   !> switch for radiative cooling
   logical, public                         :: ffhd_radiative_cooling = .false.
-  !$acc declare copyin(ffhd_radiative_cooling)
+  ${GPU_DECLARE_COPYIN('ffhd_radiative_cooling')}$
 
   !> switch for source user
   logical, public                         :: ffhd_source_usr = .false.
-  !$acc declare copyin(ffhd_source_usr)
+  ${GPU_DECLARE_COPYIN('ffhd_source_usr')}$
 
 #:enddef
 
@@ -112,12 +113,7 @@
 111    close(unitpar)
     end do
 
-#ifdef _OPENACC
-    !$acc update device( &
-    !$acc&         ffhd_energy, ffhd_gamma, ffhd_partial_ionization, &
-    !$acc&         ffhd_gravity, ffhd_radiative_cooling, ffhd_hyperbolic_thermal_conduction, &
-    !$acc&         ffhd_source_usr, ffhd_pdivb, He_abundance )
-#endif
+    ${GPU_UPDATE_DEVICE('ffhd_energy, ffhd_gamma, ffhd_partial_ionization, ffhd_gravity, ffhd_radiative_cooling, ffhd_hyperbolic_thermal_conduction, ffhd_source_usr, ffhd_pdivb, He_abundance')}$
 
 
   end subroutine read_params
@@ -208,7 +204,7 @@
     end if
     unit_mass=unit_density*unit_length**3
 
-    !$acc update device(unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass)
+    ${GPU_UPDATE_DEVICE('unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass')}$
   end subroutine phys_units
 #:enddef
   
@@ -231,15 +227,15 @@
     phys_partial_ionization=ffhd_partial_ionization
     gamma_1 = ffhd_gamma - 1.0d0
     inv_gamma_1 = 1.0d0/gamma_1
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1)
+    ${GPU_UPDATE_DEVICE('physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1')}$
 
     ! Determine flux variables
     rho_ = var_set_rho()
-    !$acc update device(rho_)
+    ${GPU_UPDATE_DEVICE('rho_')}$
 
     allocate(mom(1))
     mom(:) = var_set_momentum(1)
-    !$acc update device(mom)
+    ${GPU_UPDATE_DEVICE('mom')}$
 
     ! Set index of energy variable
     if (ffhd_energy) then
@@ -249,27 +245,27 @@
        e_ = -1
        p_ = -1
     end if
-    !$acc update device(e_,p_)
+    ${GPU_UPDATE_DEVICE('e_,p_')}$
 
     ! Set index for heat flux
 #:if defined('HYPERTC')
     q_ = var_set_q()
     need_global_cmax = .true.
     hypertc_kappa = 8.d-7*unit_temperature**3.5_dp/unit_length/unit_density/unit_velocity**3.0_dp
-    !$acc update device(q_)
-    !$acc update device(need_global_cmax)
-    !$acc update device(hypertc_kappa)
+    ${GPU_UPDATE_DEVICE('q_')}$
+    ${GPU_UPDATE_DEVICE('need_global_cmax')}$
+    ${GPU_UPDATE_DEVICE('hypertc_kappa')}$
 #:endif
 
     ! Set index of frozen magnetic field
     iw_b1 = var_set_extravar('b1', 'b1')
     iw_b2 = var_set_extravar('b2', 'b2')
     iw_b3 = var_set_extravar('b3', 'b3')
-    !$acc update device(iw_b1, iw_b2, iw_b3)
+    ${GPU_UPDATE_DEVICE('iw_b1, iw_b2, iw_b3')}$
 
     ! set number of variables which need update ghostcells
     nwgc=nwflux
-    !$acc update device(nwgc)
+    ${GPU_UPDATE_DEVICE('nwgc')}$
 
     ! Define custom flux types:
     if (.not. allocated(flux_type)) then
@@ -278,13 +274,13 @@
     else if (any(shape(flux_type) /= [ndir, nw_flux])) then
        call mpistop("phys_check error: flux_type has wrong shape")
     end if
-    !$acc update device(flux_type)
+    ${GPU_UPDATE_DEVICE('flux_type')}$
     
 #:if defined('COOLING')
     call radiative_cooling_init_params(phys_gamma,He_abundance)
     call radiative_cooling_init(rc_fl)
-    !$acc update device(rc_fl)
-    !$acc enter data copyin(rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc)
+    ${GPU_UPDATE_DEVICE('rc_fl')}$
+    ${GPU_ENTER_DATA_COPYIN('rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc')}$
 #:endif
 
   end subroutine phys_init
@@ -292,7 +288,7 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
@@ -318,7 +314,7 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
@@ -375,7 +371,7 @@ end subroutine addsource_local
 #:def addsource_nonlocal()
 subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir, &
      qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   use mod_global_parameters, only: dt, cmax_global, courantpar, third
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
@@ -431,7 +427,7 @@ end subroutine addsource_nonlocal
 
 #:def to_primitive()
 pure subroutine to_primitive(u)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(inout) :: u(nw_phys)
 
   u(iw_mom(1)) = u(iw_mom(1))/u(iw_rho)
@@ -444,7 +440,7 @@ end subroutine to_primitive
 
 #:def to_conservative()  
 pure subroutine to_conservative(u)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(inout) :: u(nw_phys)
 
   ! Compute energy from pressure and kinetic energy
@@ -459,7 +455,7 @@ end subroutine to_conservative
 
 #:def get_flux()
 subroutine get_flux(u, xC, flux_dim, flux)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: xC(1:ndim)
@@ -491,7 +487,7 @@ end subroutine get_flux
 
 #:def get_cmax()  
 pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
   integer, intent(in)   :: flux_dim
@@ -506,7 +502,7 @@ end function get_cmax
 
 #:def get_rho()
 pure real(dp) function get_rho(w, x) result(rho)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
@@ -516,7 +512,7 @@ end function get_rho
 
 #:def get_pthermal()
 pure real(dp) function get_pthermal(w, x) result(pth)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
@@ -526,7 +522,7 @@ end function get_pthermal
 
 #:def get_Rfactor()
 pure real(dp) function get_Rfactor() result(Rfactor)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   Rfactor = 1.0d0
 end function get_Rfactor
 #:enddef

--- a/src/ffhd/mod_ffhd_templates.fpp
+++ b/src/ffhd/mod_ffhd_templates.fpp
@@ -288,15 +288,15 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
-    real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
-    real(dp), intent(out)  :: dtnew
-    ! .. local ..
-    integer                :: idim
-    real(dp)               :: field
+  ${GPU_ROUTINE_SEQ()}$
+  real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
+  real(dp), intent(out)  :: dtnew
+  ! .. local ..
+  integer                :: idim
+  real(dp)               :: field
 
     dtnew = huge(1.0d0)
     
@@ -314,7 +314,6 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
@@ -324,6 +323,7 @@ subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
 #:if defined('COOLING')
   use mod_radiative_cooling, only: radiative_cooling_add_source
 #:endif
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCT(nw_phys), wCTprim(nw_phys)
@@ -371,8 +371,8 @@ end subroutine addsource_local
 #:def addsource_nonlocal()
 subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir, &
      qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
   use mod_global_parameters, only: dt, cmax_global, courantpar, third
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCTprim(nw_phys,5)

--- a/src/ffhd/mod_ffhd_templates.fpp
+++ b/src/ffhd/mod_ffhd_templates.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 #:if PHYS == 'ffhd'
 
 #:def phys_vars()

--- a/src/hd/mod_hd_templates.fpp
+++ b/src/hd/mod_hd_templates.fpp
@@ -283,15 +283,15 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
-    real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
-    real(dp), intent(out)  :: dtnew
-    ! .. local ..
-    integer                :: idim
-    real(dp)               :: field
+  ${GPU_ROUTINE_SEQ()}$
+  real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
+  real(dp), intent(out)  :: dtnew
+  ! .. local ..
+  integer                :: idim
+  real(dp)               :: field
 
     dtnew = huge(1.0d0)
     
@@ -309,13 +309,13 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
 #:if defined('COOLING')
   use mod_radiative_cooling, only: rc_fl, radiative_cooling_add_source
 #:endif
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCT(nw_phys), wCTprim(nw_phys)

--- a/src/hd/mod_hd_templates.fpp
+++ b/src/hd/mod_hd_templates.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 #:if PHYS == 'hd'
 
 #:if defined('N_TRACER')

--- a/src/hd/mod_hd_templates.fpp
+++ b/src/hd/mod_hd_templates.fpp
@@ -1,5 +1,6 @@
+#:include "../mod_gpu_directives.fpp"
 #:if PHYS == 'hd'
- 
+
 #:if defined('N_TRACER')
 #:set N_TRACER_ = N_TRACER
 #:else
@@ -14,67 +15,67 @@
 
   !> Whether an energy equation is used
   logical, public                         :: hd_energy = .true.
-  !$acc declare copyin(hd_energy)
+  ${GPU_DECLARE_COPYIN('hd_energy')}$
 
   !> Index of the density (in the w array)
   integer, public                         :: rho_
-  !$acc declare create(rho_)
+  ${GPU_DECLARE_CREATE('rho_')}$
 
   !> Indices of the momentum density
   integer, allocatable, public            :: mom(:)
-  !$acc declare create(mom)
+  ${GPU_DECLARE_CREATE('mom')}$
 
 #:if defined('N_TRACER')
   !> Indices of the tracers
   integer, public                         :: tracer(${N_TRACER_}$)
-  !$acc declare create(tracer)
+  ${GPU_DECLARE_CREATE('tracer')}$
 #:endif
 
   !> Index of the energy density (-1 if not present)
   integer, public                         :: e_
-  !$acc declare create(e_)
+  ${GPU_DECLARE_CREATE('e_')}$
 
   !> Index of the gas pressure (-1 if not present) should equal e_
   integer, public                         :: p_
-  !$acc declare create(p_)
+  ${GPU_DECLARE_CREATE('p_')}$
 
   !> The adiabatic index
   double precision, public                :: hd_gamma = 5.d0/3.0d0
   double precision, public                :: gamma_1, inv_gamma_1
-  !$acc declare copyin(hd_gamma)
-  !$acc declare create(gamma_1, inv_gamma_1)
+  ${GPU_DECLARE_COPYIN('hd_gamma')}$
+  ${GPU_DECLARE_CREATE('gamma_1, inv_gamma_1')}$
 
   !> The adiabatic constant
   double precision, public                :: hd_adiab = 1.0d0
-  !$acc declare copyin(hd_adiab)
+  ${GPU_DECLARE_COPYIN('hd_adiab')}$
 
   !> The helium abundance
   double precision, public                :: He_abundance=0.1d0
-  !$acc declare copyin(He_abundance)
+  ${GPU_DECLARE_COPYIN('He_abundance')}$
 
   !> Number of tracer species
   integer, public                         :: hd_n_tracer = 0
-  !$acc declare copyin(hd_n_tracer)
+  ${GPU_DECLARE_COPYIN('hd_n_tracer')}$
 
   !> Whether plasma is partially ionized
   logical, public                         :: hd_partial_ionization = .false.
-  !$acc declare copyin(hd_partial_ionization)
+  ${GPU_DECLARE_COPYIN('hd_partial_ionization')}$
   
   !> Whether to use gravity
   logical, public                         :: hd_gravity = .false.
-  !$acc declare copyin(hd_gravity)
+  ${GPU_DECLARE_COPYIN('hd_gravity')}$
 
   !> switch for radiative cooling
   logical, public                         :: hd_radiative_cooling = .false.
-  !$acc declare copyin(hd_radiative_cooling)
+  ${GPU_DECLARE_COPYIN('hd_radiative_cooling')}$
 
   !> Allows overruling default corner filling (for debug mode, since otherwise corner primitives fail)
   logical, public                         :: hd_force_diagonal = .true.
-  !$acc declare copyin(hd_force_diagonal)
+  ${GPU_DECLARE_COPYIN('hd_force_diagonal')}$
 
   !> Whether particles module is added
   logical, public                         :: hd_particles = .false.
-  !$acc declare copyin(hd_particles)
+  ${GPU_DECLARE_COPYIN('hd_particles')}$
 
 #:enddef
 
@@ -94,11 +95,7 @@
 111    close(unitpar)
     end do
 
-#ifdef _OPENACC
-    !$acc update device(hd_energy, hd_gamma, hd_adiab, &
-    !$acc&     hd_partial_ionization, hd_force_diagonal, hd_particles, &
-    !$acc&     hd_gravity, hd_n_tracer, hd_radiative_cooling, He_abundance)
-#endif
+    ${GPU_UPDATE_DEVICE('hd_energy, hd_gamma, hd_adiab, hd_partial_ionization, hd_force_diagonal, hd_particles, hd_gravity, hd_n_tracer, hd_radiative_cooling, He_abundance')}$
 
   end subroutine read_params
 #:enddef
@@ -187,7 +184,7 @@
     end if
     unit_mass=unit_density*unit_length**3
 
-    !$acc update device(unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass)
+    ${GPU_UPDATE_DEVICE('unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass')}$
   end subroutine phys_units
 #:enddef
   
@@ -210,17 +207,17 @@
     phys_partial_ionization=hd_partial_ionization
     gamma_1 = hd_gamma - 1.0d0
     inv_gamma_1 = 1.0d0/gamma_1
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1)
+    ${GPU_UPDATE_DEVICE('physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization, gamma_1, inv_gamma_1')}$
 
     use_particles = hd_particles
 
     ! Determine flux variables
     rho_ = var_set_rho()
-    !$acc update device(rho_)
+    ${GPU_UPDATE_DEVICE('rho_')}$
 
     allocate(mom(ndir))
     mom(:) = var_set_momentum(ndir)
-    !$acc update device(mom)
+    ${GPU_UPDATE_DEVICE('mom')}$
 
     ! Set index of energy variable
     if (hd_energy) then
@@ -230,7 +227,7 @@
        e_ = -1
        p_ = -1
     end if
-    !$acc update device(e_,p_)
+    ${GPU_UPDATE_DEVICE('e_,p_')}$
 
     ! Whether diagonal ghost cells are required for the physics
     phys_req_diagonal = .false.
@@ -245,12 +242,12 @@
     #:for i in range(1, N_TRACER_+1)
         tracer(${i}$) = var_set_fluxvar("trc", "trp", ${i}$, need_bc=.false.)
     #:endfor
-    !$acc update device(tracer)
+    ${GPU_UPDATE_DEVICE('tracer')}$
 #:endif
 
     ! set number of variables which need update ghostcells
     nwgc=nwflux
-    !$acc update device(nwgc)
+    ${GPU_UPDATE_DEVICE('nwgc')}$
 
     ! Define custom flux types:
     if (.not. allocated(flux_type)) then
@@ -259,7 +256,7 @@
     else if (any(shape(flux_type) /= [ndir, nw_flux])) then
        call mpistop("phys_check error: flux_type has wrong shape")
     end if
-    !$acc update device(flux_type)
+    ${GPU_UPDATE_DEVICE('flux_type')}$
     
 ! use cycle, needs to be dealt with:    
 !    ! Initialize particles module
@@ -271,14 +268,14 @@
     nvector      = 1 ! No. vector vars
     allocate(iw_vector(nvector))
     iw_vector(1) = mom(1) - 1
-    !$acc update device(nvector, iw_vector)
-    !$acc update device(phys_req_diagonal)
+    ${GPU_UPDATE_DEVICE('nvector, iw_vector')}$
+    ${GPU_UPDATE_DEVICE('phys_req_diagonal')}$
 
 #:if defined('COOLING')
     call radiative_cooling_init_params(phys_gamma,He_abundance)
     call radiative_cooling_init(rc_fl)
-    !$acc update device(rc_fl)
-    !$acc enter data copyin(rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc)
+    ${GPU_UPDATE_DEVICE('rc_fl')}$
+    ${GPU_ENTER_DATA_COPYIN('rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc')}$
 #:endif
 
   end subroutine phys_init
@@ -286,7 +283,7 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
@@ -312,7 +309,7 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
@@ -360,7 +357,7 @@ end subroutine addsource_local
 
 #:def to_primitive()
 pure subroutine to_primitive(u)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(inout) :: u(nw_phys)
 
   ! Compute velocity from momentum
@@ -377,7 +374,7 @@ end subroutine to_primitive
 
 #:def to_conservative()  
 pure subroutine to_conservative(u)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(inout) :: u(nw_phys)
 
   ! Compute energy from pressure and kinetic energy
@@ -394,7 +391,7 @@ end subroutine to_conservative
 
 #:def get_flux()
 subroutine get_flux(u, xC, flux_dim, flux)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
@@ -427,7 +424,7 @@ end subroutine get_flux
 
 #:def get_cmax()  
 pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
   integer, intent(in)   :: flux_dim
@@ -442,7 +439,7 @@ end function get_cmax
 !> Wave speed estimates: min/max acoustic bounds (Davis 1988) 
 !> Reference: Toro 2010, Chapter 10.
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
@@ -464,7 +461,7 @@ end subroutine estimate_speeds_minmax
 !> Wave speed estimates for HLL/HLLC using Toro (2010) PVRS pressure estimate
 !> Implements Eq. (10.67)-(10.69)
 subroutine estimate_speeds_toro_pvrs(uL, uR, xC, flux_dim, sL, sR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer,  intent(in)  :: flux_dim
@@ -515,7 +512,7 @@ end subroutine estimate_speeds_toro_pvrs
 
 #:def get_rho()
   pure real(dp) function get_rho(w, x) result(rho)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: w(nw_phys)
     real(dp), intent(in)  :: x(1:ndim)
 
@@ -525,7 +522,7 @@ end subroutine estimate_speeds_toro_pvrs
 
 #:def get_pthermal()
 pure double precision function get_pthermal(w, x) result(pth)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   double precision, intent(in)  :: w(nw_flux)
   double precision, intent(in)  :: x(1:ndim)
 
@@ -535,7 +532,7 @@ end function get_pthermal
 
 #:def get_Rfactor()
 pure double precision function get_Rfactor() result(Rfactor)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   Rfactor = 1.0d0
 end function get_Rfactor
 #:enddef

--- a/src/io/mod_input_output.fpp
+++ b/src/io/mod_input_output.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 !> Module for reading input and writing output
 module mod_input_output
 #ifdef USE_MPIWRAPPERS

--- a/src/io/mod_input_output.fpp
+++ b/src/io/mod_input_output.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 !> Module for reading input and writing output
 module mod_input_output
 #ifdef USE_MPIWRAPPERS
@@ -571,7 +572,7 @@ contains
           enddo
        enddo
     enddo
-    !$acc update device(kr,lvc)
+    ${GPU_UPDATE_DEVICE('kr,lvc')}$
 
     ! These are used to construct file and log names from multiple par files
     basename_full = ''
@@ -1582,7 +1583,7 @@ contains
     if(stagger_grid .and. refine_max_level>1 .and. mod(nghostcells,2)/=0) then
       nghostcells=nghostcells+1
    end if
-   !$acc update device(nghostcells)
+   ${GPU_UPDATE_DEVICE('nghostcells')}$
 
       select case (coordinate)
 
@@ -2032,18 +2033,18 @@ contains
 
     deallocate(flux_scheme)
 
-    !$acc update device(ixGhi1,ixGhi2,ixGhi3,ixGshi1,ixGshi2,ixGshi3,schmid_rad1,schmid_rad2,schmid_rad3,cada3_radius)
-    !$acc update device(fix_small_values,H_correction,type_limiter, max_blocks)
-    !$acc update device(rk_beta11,rk_beta22,rk_beta33,rk_beta44,rk_c2,rk_c3,rk_c4)
-    !$acc update device(rk_alfa21,rk_alfa22,rk_alfa31,rk_alfa33,rk_alfa41,rk_alfa44)
-    !$acc update device(rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,rk_alfa55,rk_c5)
-    !$acc update device(typeboundary, specialboundary, refine_max_level)
-    !$acc update device(slab, slab_uniform)
-    !$acc update device(w_refine_weight, amr_wavefilter)
-    !$acc update device(refine_threshold, derefine_ratio)
-    !$acc update device(block_nx1, block_nx2, block_nx3)
-    !$acc update device(courantpar, dtdiffpar)
-    !$acc update device(flux_adaptive_diffusion, flux_ad_min, flux_ad_scale)
+    ${GPU_UPDATE_DEVICE('ixGhi1,ixGhi2,ixGhi3,ixGshi1,ixGshi2,ixGshi3,schmid_rad1,schmid_rad2,schmid_rad3,cada3_radius')}$
+    ${GPU_UPDATE_DEVICE('fix_small_values,H_correction,type_limiter, max_blocks')}$
+    ${GPU_UPDATE_DEVICE('rk_beta11,rk_beta22,rk_beta33,rk_beta44,rk_c2,rk_c3,rk_c4')}$
+    ${GPU_UPDATE_DEVICE('rk_alfa21,rk_alfa22,rk_alfa31,rk_alfa33,rk_alfa41,rk_alfa44')}$
+    ${GPU_UPDATE_DEVICE('rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,rk_alfa55,rk_c5')}$
+    ${GPU_UPDATE_DEVICE('typeboundary, specialboundary, refine_max_level')}$
+    ${GPU_UPDATE_DEVICE('slab, slab_uniform')}$
+    ${GPU_UPDATE_DEVICE('w_refine_weight, amr_wavefilter')}$
+    ${GPU_UPDATE_DEVICE('refine_threshold, derefine_ratio')}$
+    ${GPU_UPDATE_DEVICE('block_nx1, block_nx2, block_nx3')}$
+    ${GPU_UPDATE_DEVICE('courantpar, dtdiffpar')}$
+    ${GPU_UPDATE_DEVICE('flux_adaptive_diffusion, flux_ad_min, flux_ad_scale')}$
 
   end subroutine read_par_files
 
@@ -2115,7 +2116,7 @@ contains
     end if
 
     do iigrid=1,igridstail; igrid=igrids(iigrid);
-       !$acc update host(ps(igrid)%w)
+       ${GPU_UPDATE_HOST('ps(igrid)%w')}$
     end do
 
     select case (ifile)
@@ -2744,7 +2745,7 @@ contains
               ps(igrid)%w(ixOmin1:ixOmax1,ixOmin2:ixOmax2,ixOmin3:ixOmax3,&
                  1:nw)=w(ixOmin1:ixOmax1,ixOmin2:ixOmax2,ixOmin3:ixOmax3,1:nw)
             end if
-            !$acc update device(bg(1)%w(:,:,:,:,igrid))
+            ${GPU_UPDATE_DEVICE('bg(1)%w(:,:,:,:,igrid)')}$
           else
             call mpi_send_wrapper([ ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3,&
                 n_values ], 2*ndim+1, MPI_INTEGER, ipe, itag, icomm, ierrmpi)
@@ -2822,7 +2823,7 @@ contains
           ps(igrid)%w(ixOmin1:ixOmax1,ixOmin2:ixOmax2,ixOmin3:ixOmax3,&
              1:nw)=w(ixOmin1:ixOmax1,ixOmin2:ixOmax2,ixOmin3:ixOmax3,1:nw)
         end if
-        !$acc update device(bg(1)%w(:,:,:,:,igrid))
+        ${GPU_UPDATE_DEVICE('bg(1)%w(:,:,:,:,igrid)')}$
       end do
     end if
 

--- a/src/limiter/mod_limiter.fpp
+++ b/src/limiter/mod_limiter.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 !> Module with slope/flux limiters
 module mod_limiter
   implicit none
@@ -7,7 +8,7 @@ module mod_limiter
   !> region but more overshooting at discontinuities
   double precision :: cada3_radius
   double precision :: schmid_rad1,schmid_rad2,schmid_rad3
-  !$acc declare create(cada3_radius, schmid_rad1,schmid_rad2,schmid_rad3)
+  ${GPU_DECLARE_CREATE('cada3_radius, schmid_rad1,schmid_rad2,schmid_rad3')}$
   integer, parameter :: limiter_minmod = 1
   integer, parameter :: limiter_woodward = 2
   integer, parameter :: limiter_mcbeta = 3

--- a/src/limiter/mod_limiter.fpp
+++ b/src/limiter/mod_limiter.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 !> Module with slope/flux limiters
 module mod_limiter
   implicit none

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 #:if PHYS == 'mhd'
 
 #:if defined('N_TRACER')
@@ -29,72 +30,72 @@
 
   !> Whether an energy equation is used
   logical, public                         :: mhd_energy = .true.
-  !$acc declare copyin(mhd_energy)
+  ${GPU_DECLARE_COPYIN('mhd_energy')}$
 
   !> Index of the density (in the w array)
   integer, public                         :: rho_
-  !$acc declare create(rho_)
+  ${GPU_DECLARE_CREATE('rho_')}$
 
   !> Indices of the momentum density
   integer, allocatable, public            :: mom(:)
-  !$acc declare create(mom)
+  ${GPU_DECLARE_CREATE('mom')}$
 
 #:if defined('N_TRACER')
   !> Indices of the tracers
   integer, public                         :: tracer(${N_TRACER_}$)
-  !$acc declare create(tracer)
+  ${GPU_DECLARE_CREATE('tracer')}$
 #:endif
 
   !> Index of the energy density (-1 if not present)
   integer, public                         :: e_
-  !$acc declare create(e_)
+  ${GPU_DECLARE_CREATE('e_')}$
 
   !> Indices of the magnetic field
   integer, allocatable, public            :: mag(:)
-  !$acc declare create(mag)
+  ${GPU_DECLARE_CREATE('mag')}$
 
   !> Index of the gas pressure (-1 if not present) should equal e_
   integer, public                         :: p_
-  !$acc declare create(p_)
+  ${GPU_DECLARE_CREATE('p_')}$
 
   !> Indices of the GLM psi
   integer, public :: psi_
-  !$acc declare create(psi_)
+  ${GPU_DECLARE_CREATE('psi_')}$
 
   !> Number of tracer species
   integer, public                         :: mhd_n_tracer = 0
-  !$acc declare copyin(mhd_n_tracer)
+  ${GPU_DECLARE_COPYIN('mhd_n_tracer')}$
 
   !> The adiabatic index
   double precision, public                :: mhd_gamma = 5.d0/3.0d0
   double precision, public                :: gamma_1, inv_gamma_1
-  !$acc declare copyin(mhd_gamma)
-  !$acc declare create(gamma_1, inv_gamma_1)
+  ${GPU_DECLARE_COPYIN('mhd_gamma')}$
+  ${GPU_DECLARE_CREATE('gamma_1, inv_gamma_1')}$
 
   !> Helium abundance over Hydrogen
   double precision, public  :: He_abundance=0.1d0
-  !$acc declare copyin(He_abundance)
+  ${GPU_DECLARE_COPYIN('He_abundance')}$
   !> Ionization fraction of H
   !> H_ion_fr = H+/(H+ + H)
   double precision, public  :: H_ion_fr=1d0
-  !$acc declare copyin(H_ion_fr)
+  ${GPU_DECLARE_COPYIN('H_ion_fr')}$
   !> Ionization fraction of He
   !> He_ion_fr = (He2+ + He+)/(He2+ + He+ + He)
   double precision, public  :: He_ion_fr=1d0
-  !$acc declare copyin(He_ion_fr)
+  ${GPU_DECLARE_COPYIN('He_ion_fr')}$
   !> Ratio of number He2+ / number He+ + He2+
   !> He_ion_fr2 = He2+/(He2+ + He+)
   double precision, public  :: He_ion_fr2=1d0
-  !$acc declare copyin(He_ion_fr2)
+  ${GPU_DECLARE_COPYIN('He_ion_fr2')}$
   ! used for eq of state when it is not defined by units,
   ! the units do not contain terms related to ionization fraction
   ! and it is p = RR * rho * T
   double precision, public  :: RR=1d0
-  !$acc declare copyin(RR)
+  ${GPU_DECLARE_COPYIN('RR')}$
 
   !> Switch for hyperbolic thermal conduction
   logical, public                         :: mhd_hyperbolic_thermal_conduction = .false.
-  !$acc declare copyin(mhd_hyperbolic_thermal_conduction)
+  ${GPU_DECLARE_COPYIN('mhd_hyperbolic_thermal_conduction')}$
 
   !> Compile-time selector for anisotropic HTC
   logical, public                         :: mhd_hyperbolic_thermal_conduction_anisotropic = .false.
@@ -104,65 +105,65 @@
 
   !> sig_par = tc_kappa_par (constant, no T^2.5); takes precedence over tc_kappa0_par when > 0
   double precision, public                :: tc_kappa_par = -1.0d0
-  !$acc declare copyin(tc_kappa_par)
+  ${GPU_DECLARE_COPYIN('tc_kappa_par')}$
 
   !> sig_perp = tc_kappa_perp (constant, no T^2.5); takes precedence over the Braginskii closure when > 0
   double precision, public                :: tc_kappa_perp = -1.0d0
-  !$acc declare copyin(tc_kappa_perp)
+  ${GPU_DECLARE_COPYIN('tc_kappa_perp')}$
 
   ! HYPERTC_ANISO implies HYPERTC (enforced in config_schema.toml)
 #:if defined('HYPERTC')
   !> sig_par = tc_kappa0_par * Te^2.5; if <= 0 and tc_kappa_par <= 0, set from Spitzer in phys_units()
   double precision, public                :: tc_kappa0_par = -1.0d0
-  !$acc declare copyin(tc_kappa0_par)
+  ${GPU_DECLARE_COPYIN('tc_kappa0_par')}$
 
 #:if defined('HYPERTC_ANISO')
   !> Indices of the heat-flux vector components q_(1:ndir); this is the full Cartesian heat-flux vector
   integer, allocatable, public            :: q_(:)
-  !$acc declare create(q_)
+  ${GPU_DECLARE_CREATE('q_')}$
 
   !> Magnetisation chi prefactor: chi = htc_Cchi * B * Te^1.5 / n
   double precision, public                :: htc_Cchi = 0.0d0
-  !$acc declare copyin(htc_Cchi)
+  ${GPU_DECLARE_COPYIN('htc_Cchi')}$
 #:else
   !> Index of the field-aligned heat flux scalar q_ (isotropic HTC only)
   integer, public                         :: q_ = -1
-  !$acc declare create(q_)
+  ${GPU_DECLARE_CREATE('q_')}$
 #:endif
 #:endif
 
   !> GLM-MHD parameter: ratio of the diffusive and advective time scales for div b
   !> taking values within [0, 1]
   double precision, public                :: mhd_glm_alpha = 0.5d0
-  !$acc declare copyin(mhd_glm_alpha)
+  ${GPU_DECLARE_COPYIN('mhd_glm_alpha')}$
 
   !> Whether to use gravity
   logical, public                         :: mhd_gravity = .false.
-  !$acc declare copyin(mhd_gravity)
+  ${GPU_DECLARE_COPYIN('mhd_gravity')}$
 
   !> The resistivity
   double precision, public                :: mhd_eta = 0.0d0
-  !$acc declare copyin(mhd_eta)
+  ${GPU_DECLARE_COPYIN('mhd_eta')}$
 
   !> switch for adding resistive terms
   logical, public                         :: mhd_resistivity = .false.
-  !$acc declare copyin(mhd_resistivity)
+  ${GPU_DECLARE_COPYIN('mhd_resistivity')}$
 
   !> Whether plasma is partially ionized
   logical, public                         :: mhd_partial_ionization = .false.
-  !$acc declare copyin(mhd_partial_ionization)
+  ${GPU_DECLARE_COPYIN('mhd_partial_ionization')}$
 
   !> switch for radiative cooling
   logical, public                         :: mhd_radiative_cooling = .false.
-  !$acc declare copyin(mhd_radiative_cooling)
+  ${GPU_DECLARE_COPYIN('mhd_radiative_cooling')}$
 
   !> Whether particles module is added
   logical, public                         :: mhd_particles = .false.
-  !$acc declare copyin(mhd_particles)
+  ${GPU_DECLARE_COPYIN('mhd_particles')}$
 
   !> switch for source user
   logical, public                         :: mhd_source_usr = .false.
-  !$acc declare copyin(mhd_source_usr)
+  ${GPU_DECLARE_COPYIN('mhd_source_usr')}$
 
 #:enddef
 
@@ -186,13 +187,8 @@
 111    close(unitpar)
     end do
 
-#ifdef _OPENACC
-    !$acc update device(mhd_energy, &
-    !$acc&     mhd_gamma, mhd_glm_alpha, &
-    !$acc&     mhd_gravity, mhd_n_tracer, mhd_radiative_cooling, &
-    !$acc&     He_abundance, mhd_eta, mhd_source_usr, mhd_resistivity)
-    !$acc update device(tc_kappa_par, tc_kappa_perp)
-#endif
+    ${GPU_UPDATE_DEVICE('mhd_energy, mhd_gamma, mhd_glm_alpha, mhd_gravity, mhd_n_tracer, mhd_radiative_cooling, He_abundance, mhd_eta, mhd_source_usr, mhd_resistivity')}$
+    ${GPU_UPDATE_DEVICE('tc_kappa_par, tc_kappa_perp')}$
 
   end subroutine read_params
 #:enddef
@@ -282,20 +278,20 @@
     end if
     unit_mass=unit_density*unit_length**3
 
-    !$acc update device(unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass)
+    ${GPU_UPDATE_DEVICE('unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass')}$
 
 #:if defined('HYPERTC')
     if (tc_kappa0_par <= 0.0d0 .and. tc_kappa_par <= 0.0d0) &
       tc_kappa0_par = 8.0d-7 * unit_temperature**3.5d0 &
                     / (unit_length * unit_density * unit_velocity**3.0d0)
-    !$acc update device(tc_kappa0_par)
-    !$acc update device(tc_kappa_par)
+    ${GPU_UPDATE_DEVICE('tc_kappa0_par')}$
+    ${GPU_UPDATE_DEVICE('tc_kappa_par')}$
 #:endif
 #:if defined('HYPERTC_ANISO')
     htc_Cchi = 0.823d0 * (4.753567596681522d6 / 20.0d0) &
              * unit_magneticfield * unit_temperature**1.5d0 / unit_numberdensity
-    !$acc update device(htc_Cchi)
-    !$acc update device(tc_kappa_perp)
+    ${GPU_UPDATE_DEVICE('htc_Cchi')}$
+    ${GPU_UPDATE_DEVICE('tc_kappa_perp')}$
 #:endif
   end subroutine phys_units
 #:enddef
@@ -321,17 +317,17 @@
     need_global_cmax=.true.
     gamma_1=mhd_gamma-1.0_dp
     inv_gamma_1=1.0_dp/gamma_1
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,gamma_1,inv_gamma_1)
+ ${GPU_UPDATE_DEVICE('physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,gamma_1,inv_gamma_1')}$
 
     use_particles = mhd_particles
 
     ! Determine flux variables
     rho_ = var_set_rho()
-    !$acc update device(rho_)
+    ${GPU_UPDATE_DEVICE('rho_')}$
 
     allocate(mom(ndir))
     mom(:) = var_set_momentum(ndir)
-    !$acc update device(mom)
+    ${GPU_UPDATE_DEVICE('mom')}$
 
     ! Set index of energy variable
     if (mhd_energy) then
@@ -341,28 +337,28 @@
        e_ = -1
        p_ = -1
     end if
-    !$acc update device(e_,p_)
+    ${GPU_UPDATE_DEVICE('e_,p_')}$
 
     ! Set index for heat flux variable(s)
 #:if defined('HYPERTC_ANISO')
     allocate(q_(ndir))
     q_ = var_set_qvec(ndir, need_bc=.false.)
-    !$acc update device(q_)
+    ${GPU_UPDATE_DEVICE('q_')}$
 #:elif defined('HYPERTC')
     q_ = var_set_q(need_bc=.false.)
-    !$acc update device(q_)
+    ${GPU_UPDATE_DEVICE('q_')}$
 #:endif
 
     allocate(mag(ndir))
     mag(:) = var_set_bfield(ndir)
-    !$acc update device(mag)
+    ${GPU_UPDATE_DEVICE('mag')}$
 
     psi_ = var_set_fluxvar('psi', 'psi', need_bc=.false.)
-    !$acc update device(psi_)
+    ${GPU_UPDATE_DEVICE('psi_')}$
 
     !> GLM MHD uses split source addition in psi:
     any_source_split = .true.
-    !$acc update device(any_source_split)
+    ${GPU_UPDATE_DEVICE('any_source_split')}$
 
     ! Whether diagonal ghost cells are required for the physics
     phys_req_diagonal = .true.
@@ -372,12 +368,12 @@
     #:for i in range(1, N_TRACER_+1)
         tracer(${i}$) = var_set_fluxvar("trc", "trp", ${i}$, need_bc=.false.)
     #:endfor
-    !$acc update device(tracer)
+    ${GPU_UPDATE_DEVICE('tracer')}$
 #:endif
 
     ! set number of variables which need update ghostcells
     nwgc=nwflux
-    !$acc update device(nwgc)
+    ${GPU_UPDATE_DEVICE('nwgc')}$
 
     ! Define custom flux types:
     if (.not. allocated(flux_type)) then
@@ -392,7 +388,7 @@
     do idir=1,ndir
        flux_type(idir,mag(idir))=flux_tvdlf
     end do
-    !$acc update device(flux_type)
+    ${GPU_UPDATE_DEVICE('flux_type')}$
 
     
 ! use cycle, needs to be dealt with:    
@@ -405,8 +401,8 @@
 #:if defined('COOLING')
     call radiative_cooling_init_params(phys_gamma,He_abundance)
     call radiative_cooling_init(rc_fl)
-    !$acc update device(rc_fl)
-    !$acc enter data copyin(rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc)
+    ${GPU_UPDATE_DEVICE('rc_fl')}$
+    ${GPU_ENTER_DATA_COPYIN('rc_fl%tcool,rc_fl%Lcool, rc_fl%Yc')}$
 #:endif
 
   end subroutine phys_init
@@ -414,7 +410,7 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
@@ -449,7 +445,7 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
@@ -507,7 +503,7 @@ end subroutine addsource_local
 #:def addsource_compact()
 subroutine addsource_compact(qdt, dtfactor, qtC, wCTprim1, wCTprim2, wCTprim3, qt, wnew, x, dx, &
      qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('HYPERTC')
   use mod_global_parameters, only: dt, ndir, smalldouble, courantpar
 #:endif
@@ -705,7 +701,7 @@ end subroutine addsource_compact
 
 #:def to_primitive()
   pure subroutine to_primitive(u)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: u(nw_phys)
 
     u(iw_mom(1))=u(iw_mom(1))/u(iw_rho)
@@ -720,7 +716,7 @@ end subroutine addsource_compact
 
 #:def to_conservative()  
   pure subroutine to_conservative(u)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: u(nw_phys)
 
     ! Compute energy from pressure and kinetic energy
@@ -741,7 +737,7 @@ end subroutine addsource_compact
 #:if defined('HYPERTC')
     use mod_global_parameters, only: smalldouble
 #:endif
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys)
     real(dp), intent(in)  :: xC(1:ndim)
     integer, intent(in)   :: flux_dim
@@ -821,7 +817,7 @@ end subroutine addsource_compact
 !> Returns maximum local signal speed |v_n| + c_f (fast magnetosonic) from primitive state u in direction flux_dim;
 !> used in LLF/TVDLF flux estimation.
 pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
   integer, intent(in)   :: flux_dim
@@ -840,7 +836,7 @@ end function get_cmax
 
 #:def get_rho()
   pure real(dp) function get_rho(w, x) result(rho)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: w(nw_phys)
     real(dp), intent(in)  :: x(1:ndim)
 
@@ -850,7 +846,7 @@ end function get_cmax
 
 #:def get_pthermal()
 pure real(dp) function get_pthermal(w, x) result(pth)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
@@ -861,7 +857,7 @@ end function get_pthermal
 
 #:def get_Rfactor()
 pure real(dp) function get_Rfactor() result(Rfactor)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   Rfactor = 1.0d0
 end function get_Rfactor
 #:enddef
@@ -870,7 +866,7 @@ end function get_Rfactor
 !> Davis (1988) min/max wave speed estimates wL = min(v_n - c_f), wR = max(v_n + c_f) (fast magnetosonic) over left/right states;
 !> used in HLL flux estimation.
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -410,18 +410,18 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('GRAVITY')
   use mod_usr, only: gravity_field
 #:endif    
 #:if defined('RESISTIVE')
   use mod_global_parameters, only: dtdiffpar
 #:endif    
-    real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
-    real(dp), intent(out)  :: dtnew
-    ! .. local ..
-    integer                :: idim
-    real(dp)               :: field
+  ${GPU_ROUTINE_SEQ()}$
+  real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
+  real(dp), intent(out)  :: dtnew
+  ! .. local ..
+  integer                :: idim
+  real(dp)               :: field
 
     dtnew = huge(1.0d0)
     
@@ -445,7 +445,6 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
@@ -455,8 +454,8 @@ subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
 #:if defined('COOLING')
   use mod_radiative_cooling, only: rc_fl, radiative_cooling_add_source
 #:endif
-
   use mod_global_parameters, only:cmax_global
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCT(nw_phys), wCTprim(nw_phys)
   real(dp), intent(in)     :: x(1:ndim), dr(ndim)
@@ -503,10 +502,10 @@ end subroutine addsource_local
 #:def addsource_compact()
 subroutine addsource_compact(qdt, dtfactor, qtC, wCTprim1, wCTprim2, wCTprim3, qt, wnew, x, dx, &
      qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('HYPERTC')
   use mod_global_parameters, only: dt, ndir, smalldouble, courantpar
 #:endif
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCTprim1(nw_phys,3),wCTprim2(nw_phys,3),wCTprim3(nw_phys,3)

--- a/src/mhd/mod_mhd_templates.fpp
+++ b/src/mhd/mod_mhd_templates.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 #:if PHYS == 'mhd'
 
 #:if defined('N_TRACER')

--- a/src/mod_advance.fpp
+++ b/src/mod_advance.fpp
@@ -232,17 +232,8 @@ contains
     double precision, intent(in) :: qtC
     double precision, intent(in) :: qt
     integer, intent(in)          :: method(nlevelshi)
-
-    ! cell face flux
-    double precision             :: fC(ixGlo1:ixGhi1,ixGlo2:ixGhi2,&
-       ixGlo3:ixGhi3,1:nwflux,1:ndim)
-    ! cell edge flux
-    double precision             :: fE(ixGlo1:ixGhi1,ixGlo2:ixGhi2,&
-       ixGlo3:ixGhi3,sdim:3)
     double precision             :: qdt
     integer                      :: iigrid, igrid
-
-    ${GPU_ENTER_DATA_CREATE('fC,fE')}$
 
     istep = istep+1
 
@@ -268,8 +259,7 @@ contains
         qtC, &                          ! scalar related to time stepping
         bga, &                          ! first block grid
         qt,  &                          ! scalar related to time stepping
-        bgb, &                          ! second block grid
-        fC, fE &                        ! fluxes
+        bgb  &                          ! second block grid
         )
 
     ! AGILE: todo
@@ -290,8 +280,6 @@ contains
     
     ! For all grids: fill ghost cells
     call getbc(qt+qdt,qdt,psb,iwstart,nwgc,phys_req_diagonal)
-
-    ${GPU_EXIT_DATA_DELETE('fC,fE')}$
 
   end subroutine advect1
 

--- a/src/mod_advance.fpp
+++ b/src/mod_advance.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> Module containing all the time stepping schemes
 module mod_advance
 
@@ -72,10 +73,9 @@ contains
     fix_conserve_at_step = time_advance .and. levmax>levmin
     
     ! copy w instead of wold because of potential use of dimsplit or sourcesplit
-    !$OMP PARALLEL DO PRIVATE(igrid)
-    !$acc parallel loop present(bg, bg(1), bg(2)) private(igrid)
+    ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$ ${GPU_PRESENT('bg, bg(1), bg(2)')}$
     do iigrid=1,igridstail; igrid=igrids(iigrid);
-       !$acc loop collapse(ndim+1)
+       ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$
        do iw = 1, nw
           do ix3 = ixGlo3, ixGhi3 
              do ix2 = ixGlo2, ixGhi2 
@@ -86,13 +86,11 @@ contains
           end do
        end do
     end do
-    !$OMP END PARALLEL DO
     
     if(stagger_grid) then
-       !$OMP PARALLEL DO PRIVATE(igrid)
-       !$acc parallel loop present(ps1, ps) private(igrid)
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$ ${GPU_PRESENT('ps1, ps')}$
        do iigrid=1,igridstail; igrid=igrids(iigrid);
-          !$acc loop collapse(ndim+1)
+          ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$
           do iw = 1, nws
              do ix3 = ps(igrid)%ixGsmin3, ps(igrid)%ixGsmax3 
                 do ix2 = ps(igrid)%ixGsmin2, ps(igrid)%ixGsmax2 
@@ -104,7 +102,6 @@ contains
           end do
        end do
     end if
-    !$OMP END PARALLEL DO
 
  istep = 0
 
@@ -119,10 +116,9 @@ contains
           call advect1(flux_method,rk_beta11, idimmin,idimmax,global_time,ps,&
                bg(1),global_time,ps1,bg(2))
 
-          !$OMP PARALLEL DO PRIVATE(igrid)
-          !$acc parallel loop present(bg, ps2, ps1, ps) private(igrid)
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$ ${GPU_PRESENT('bg, ps2, ps1, ps')}$
           do iigrid=1,igridstail_active; igrid=igrids_active(iigrid);
-             !$acc loop collapse(ndim+1)
+             ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$
              do iw = 1, nw
                 do ix3 = ixGlo3, ixGhi3 
                    do ix2 = ixGlo2, ixGhi2 
@@ -136,16 +132,14 @@ contains
              if(stagger_grid) ps2(igrid)%ws=rk_alfa21*ps(igrid)%ws+&
                   rk_alfa22*ps1(igrid)%ws
           end do
-          !$OMP END PARALLEL DO
 
           call advect1(flux_method,rk_beta22, idimmin,idimmax,&
                global_time+rk_c2*dt,ps1,bg(2),global_time+rk_alfa22*rk_c2*dt,ps2,&
                bg(3))
 
-          !$OMP PARALLEL DO PRIVATE(igrid)
-          !$acc parallel loop present(bg, ps2, ps) private(igrid)
+          ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$ ${GPU_PRESENT('bg, ps2, ps')}$
           do iigrid=1,igridstail_active; igrid=igrids_active(iigrid);
-             !$acc loop collapse(ndim+1)
+             ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$
              do iw = 1, nw
                 do ix3 = ixGlo3, ixGhi3 
                    do ix2 = ixGlo2, ixGhi2 
@@ -159,7 +153,6 @@ contains
              if(stagger_grid) ps(igrid)%ws=rk_alfa31*ps(igrid)%ws+&
                   rk_alfa33*ps2(igrid)%ws
           end do
-          !$OMP END PARALLEL DO
 
           call advect1(flux_method,rk_beta33, idimmin,idimmax,&
                global_time+rk_c3*dt,ps2,bg(3),global_time+(1.0d0-rk_beta33)*dt,&
@@ -244,9 +237,10 @@ contains
     ! cell edge flux
     double precision             :: fE(ixGlo1:ixGhi1,ixGlo2:ixGhi2,&
        ixGlo3:ixGhi3,sdim:3)
-    !$acc declare create(fC,fE)
     double precision             :: qdt
     integer                      :: iigrid, igrid
+
+    ${GPU_ENTER_DATA_CREATE('fC,fE')}$
 
     istep = istep+1
 
@@ -284,19 +278,19 @@ contains
     !   if(stagger_grid) then
     !     call fix_edges(psb,idimmin,idimmax)
     !     ! fill the cell-center values from the updated staggered variables
-    !     !$OMP PARALLEL DO PRIVATE(igrid)
     !     do iigrid=1,igridstail_active; igrid=igrids_active(iigrid);
     !       call phys_face_to_center(ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,&
     !          psb(igrid))
     !     end do
-    !     !$OMP END PARALLEL DO
     !   end if
     ! end if
 
     
     ! For all grids: fill ghost cells
     call getbc(qt+qdt,qdt,psb,iwstart,nwgc,phys_req_diagonal)
-    
+
+    ${GPU_EXIT_DATA_DELETE('fC,fE')}$
+
   end subroutine advect1
 
   !> process is a user entry in time loop, before output and advance
@@ -318,7 +312,6 @@ contains
     end if
 
     if (associated(usr_process_grid)) then
-      !$OMP PARALLEL DO PRIVATE(igrid)
       do iigrid=1,igridstail; igrid=igrids(iigrid);
          ! next few lines ensure correct usage of routines like divvector etc
          dxlevel(1)=rnode(rpdx1_,igrid);dxlevel(2)=rnode(rpdx2_,igrid)
@@ -328,7 +321,6 @@ contains
             ixGhi1,ixGhi2,ixGhi3,ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3, qt,&
             ps(igrid)%w,ps(igrid)%x)
       end do
-      !$OMP END PARALLEL DO
       call getbc(qt,dt,ps,iwstart,nwgc,phys_req_diagonal)
     end if
   end subroutine process
@@ -353,7 +345,6 @@ contains
     end if
 
     if (associated(usr_process_adv_grid)) then
-      !$OMP PARALLEL DO PRIVATE(igrid)
       do iigrid=1,igridstail; igrid=igrids(iigrid);
          ! next few lines ensure correct usage of routines like divvector etc
          dxlevel(1)=rnode(rpdx1_,igrid);dxlevel(2)=rnode(rpdx2_,igrid)
@@ -364,7 +355,6 @@ contains
             ixGlo3,ixGhi1,ixGhi2,ixGhi3,ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,&
             ixMhi3, qt,ps(igrid)%w,ps(igrid)%x)
       end do
-      !$OMP END PARALLEL DO
       call getbc(qt,dt,ps,iwstart,nwgc,phys_req_diagonal)
     end if
   end subroutine process_advanced

--- a/src/mod_advance.fpp
+++ b/src/mod_advance.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> Module containing all the time stepping schemes
 module mod_advance
 

--- a/src/mod_boundary_conditions.fpp
+++ b/src/mod_boundary_conditions.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 module mod_boundary_conditions
 
   implicit none

--- a/src/mod_boundary_conditions.fpp
+++ b/src/mod_boundary_conditions.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 module mod_boundary_conditions
 
   implicit none
@@ -11,7 +12,7 @@ contains
   !> fill ghost cells at a physical boundary
   subroutine bc_phys(iside,idims,time,qdt,s,ixGmin1,ixGmin2,ixGmin3,ixGmax1,&
        ixGmax2,ixGmax3,ixBmin1,ixBmin2,ixBmin3,ixBmax1,ixBmax2,ixBmax3)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
 #:if defined('SPECIALBOUNDARY')    
     use mod_usr, only: specialbound_usr
 #:endif
@@ -399,7 +400,6 @@ contains
     ixOmin3=ixGmin3+nghostcells;ixOmax1=ixGmax1-nghostcells
     ixOmax2=ixGmax2-nghostcells;ixOmax3=ixGmax3-nghostcells;
 
-    !$OMP PARALLEL DO SCHEDULE(dynamic) PRIVATE(igrid)
     do iigrid=1,igridstail_active; igrid=igrids_active(iigrid);
        block=>ps(igrid)
        dxlevel(1)=rnode(rpdx1_,igrid);dxlevel(2)=rnode(rpdx2_,igrid)
@@ -411,7 +411,6 @@ contains
              ixOmax2,ixOmax3,ps(igrid)%w,ps(igrid)%x)
        end if
     end do
-    !$OMP END PARALLEL DO
 
   end subroutine getintbc
 

--- a/src/mod_boundary_conditions.fpp
+++ b/src/mod_boundary_conditions.fpp
@@ -12,11 +12,11 @@ contains
   !> fill ghost cells at a physical boundary
   subroutine bc_phys(iside,idims,time,qdt,s,ixGmin1,ixGmin2,ixGmin3,ixGmax1,&
        ixGmax2,ixGmax3,ixBmin1,ixBmin2,ixBmin3,ixBmax1,ixBmax2,ixBmax3)
-    ${GPU_ROUTINE_VECTOR()}$
 #:if defined('SPECIALBOUNDARY')    
     use mod_usr, only: specialbound_usr
 #:endif
     use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
 
     integer, intent(in) :: iside, idims, ixGmin1,ixGmin2,ixGmin3,ixGmax1,&
        ixGmax2,ixGmax3,ixBmin1,ixBmin2,ixBmin3,ixBmax1,ixBmax2,ixBmax3

--- a/src/mod_comm_lib.fpp
+++ b/src/mod_comm_lib.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 module mod_comm_lib
 
   implicit none

--- a/src/mod_comm_lib.fpp
+++ b/src/mod_comm_lib.fpp
@@ -227,10 +227,10 @@ contains
   !> Exit MPI-AMRVAC with an error message
   ! cray does not allow char type on the GPU
   subroutine mpistop(message)
+    use mod_global_parameters
 #ifndef _CRAYFTN
     ${GPU_ROUTINE()}$
 #endif
-    use mod_global_parameters
 
     character(len=*), intent(in) :: message !< The error message
     integer                      :: ierrcode
@@ -248,8 +248,8 @@ contains
   end subroutine mpistop
 
   subroutine mpistop_gpu()
-    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
 
     integer                      :: ierrcode
 

--- a/src/mod_comm_lib.fpp
+++ b/src/mod_comm_lib.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 module mod_comm_lib
 
   implicit none
@@ -26,7 +27,7 @@ contains
     ! Store the number of processes
     call MPI_COMM_SIZE(MPI_COMM_WORLD,npe,ierrmpi)
 
-    !$acc update device(mype,npe)
+    ${GPU_UPDATE_DEVICE('mype,npe')}$
 
     ! Use the default communicator, which contains all the processes
     icomm = MPI_COMM_WORLD
@@ -227,7 +228,7 @@ contains
   ! cray does not allow char type on the GPU
   subroutine mpistop(message)
 #ifndef _CRAYFTN
-    !$acc routine
+    ${GPU_ROUTINE()}$
 #endif
     use mod_global_parameters
 
@@ -236,7 +237,7 @@ contains
 
     write(*, *) "ERROR for processor", mype, ":"
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(_OPENMP)
     write(*, *) message
     STOP
 #else
@@ -247,7 +248,7 @@ contains
   end subroutine mpistop
 
   subroutine mpistop_gpu()
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
 
     integer                      :: ierrcode

--- a/src/mod_connectivity.fpp
+++ b/src/mod_connectivity.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> This module contains variables that describe the connectivity of the mesh and
 !> also data structures for connectivity-related communication.
 module mod_connectivity

--- a/src/mod_connectivity.fpp
+++ b/src/mod_connectivity.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> This module contains variables that describe the connectivity of the mesh and
 !> also data structures for connectivity-related communication.
 module mod_connectivity
@@ -13,23 +14,23 @@ module mod_connectivity
    integer, dimension(:,:,:,:), allocatable :: neighbor_type
    logical, dimension(:,:,:,:), allocatable :: neighbor_active
    integer, dimension(:,:,:,:), allocatable :: neighbor_pole
-   !$acc declare create(neighbor, neighbor_type, neighbor_pole, neighbor_child)
+   ${GPU_DECLARE_CREATE('neighbor, neighbor_type, neighbor_pole, neighbor_child')}$
 
    ! grid number array per processor
    integer, dimension(:), allocatable :: igrids
    integer, dimension(:), allocatable :: igrids_active
    integer, dimension(:), allocatable :: igrids_passive
-   !$acc declare create(igrids, igrids_active, igrids_passive)
+   ${GPU_DECLARE_CREATE('igrids, igrids_active, igrids_passive')}$
 
    ! phys boundary indices
    integer, dimension(:,:), allocatable :: idphyb
-   !$acc declare create(idphyb)
+   ${GPU_DECLARE_CREATE('idphyb')}$
 
    ! number of grids on current processor
    integer :: igridstail
    integer :: igridstail_active
    integer :: igridstail_passive
-   !$acc declare create(igridstail, igridstail_active, igridstail_passive)
+   ${GPU_DECLARE_CREATE('igridstail, igridstail_active, igridstail_passive')}$
 
    integer, dimension(3) :: nrecv_fc, nsend_fc
    ! cc for corner coarse

--- a/src/mod_constrained_transport.fpp
+++ b/src/mod_constrained_transport.fpp
@@ -15,7 +15,6 @@ contains
 
     call init_comm_fix_conserve(1,ndim,3)
 
-    !$OMP PARALLEL DO PRIVATE(igrid)
     do iigrid=1,igridstail; igrid=igrids(iigrid);
        ! Make zero the magnetic fluxes
        ! Fake advance, storing electric fields at edges
@@ -23,7 +22,6 @@ contains
        call fake_advance(igrid,1,3,ps(igrid))
 
     end do
-    !$OMP END PARALLEL DO
 
     ! Do correction
     call recvflux(1,ndim)
@@ -33,7 +31,6 @@ contains
     call fix_edges(ps,1,3)
 
     ! Now we fill the centers for the staggered variables
-    !$OMP PARALLEL DO PRIVATE(igrid)
     do iigrid=1,igridstail_active; igrid=igrids_active(iigrid);
        call phys_to_primitive(ixGlo1,ixGlo2,ixGlo3,ixGhi1,ixGhi2,ixGhi3,ixMlo1,&
           ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,ps(igrid)%w,ps(igrid)%x)
@@ -43,7 +40,6 @@ contains
        call phys_to_conserved(ixGlo1,ixGlo2,ixGlo3,ixGhi1,ixGhi2,ixGhi3,ixMlo1,&
           ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3,ps(igrid)%w,ps(igrid)%x)
     end do
-    !$OMP END PARALLEL DO
 
     call getbc(global_time,0.d0,ps,iwstart,nwgc)
 

--- a/src/mod_dt.fpp
+++ b/src/mod_dt.fpp
@@ -34,7 +34,7 @@ contains
     if (dtpar<=zero) then
        dtmin_mype=bigdouble
 
-       ${GPU_PARALLEL_LOOP_GANG("PRIVATE(igrid,dxinv) REDUCTION(min:dtmin_mype)")}$
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid,dxinv,dx1,dx2,dx3) reduction(min:dtmin_mype)")}$
        do iigrid=1,igridstail_active; igrid=igrids_active(iigrid)
 
           dx1=rnode(rpdx1_,igrid);dx2=rnode(rpdx2_,igrid)
@@ -42,7 +42,7 @@ contains
 
           dxinv(1)=one/dx1;dxinv(2)=one/dx2;dxinv(3)=one/dx3;
 
-          ${GPU_LOOP_VECTOR("collapse(ndim) REDUCTION(min:dtmin_mype) private(u, xloc)")}$
+          ${GPU_LOOP_VECTOR("collapse(ndim) reduction(min:dtmin_mype) private(u, xloc, cmaxtot, cmax, idims, qdtnew)")}$
           do ix3=ixMlo3,ixMhi3 
              do ix2=ixMlo2,ixMhi2 
                 do ix1=ixMlo1,ixMhi1 
@@ -80,10 +80,10 @@ contains
     if (need_global_cmax) then
        cmax_mype=-bigdouble
 
-       ${GPU_PARALLEL_LOOP_GANG("PRIVATE(igrid) REDUCTION(max:cmax_mype)")}$
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid) reduction(max:cmax_mype)")}$
        do iigrid=1,igridstail_active; igrid=igrids_active(iigrid)
 
-          ${GPU_LOOP_VECTOR("collapse(ndim) REDUCTION(max:cmax_mype) private(u, xloc)")}$
+          ${GPU_LOOP_VECTOR("collapse(ndim) reduction(max:cmax_mype) private(u, xloc, cmax, idims)")}$
           do ix3=ixMlo3,ixMhi3 
              do ix2=ixMlo2,ixMhi2 
                 do ix1=ixMlo1,ixMhi1

--- a/src/mod_dt.fpp
+++ b/src/mod_dt.fpp
@@ -1,5 +1,6 @@
 #:mute
 #:include "physics/mod_physics_templates.fpp"
+#:include "mod_gpu_directives.fpp"
 #:endmute
 
 module mod_dt
@@ -32,8 +33,8 @@ contains
 
     if (dtpar<=zero) then
        dtmin_mype=bigdouble
-       
-       !$acc parallel loop PRIVATE(igrid,dxinv) REDUCTION(min:dtmin_mype) gang
+
+       ${GPU_PARALLEL_LOOP_GANG("PRIVATE(igrid,dxinv) REDUCTION(min:dtmin_mype)")}$
        do iigrid=1,igridstail_active; igrid=igrids_active(iigrid)
 
           dx1=rnode(rpdx1_,igrid);dx2=rnode(rpdx2_,igrid)
@@ -41,7 +42,7 @@ contains
 
           dxinv(1)=one/dx1;dxinv(2)=one/dx2;dxinv(3)=one/dx3;
 
-          !$acc loop vector collapse(ndim) REDUCTION(min:dtmin_mype) private(u, xloc)
+          ${GPU_LOOP_VECTOR("collapse(ndim) REDUCTION(min:dtmin_mype) private(u, xloc)")}$
           do ix3=ixMlo3,ixMhi3 
              do ix2=ixMlo2,ixMhi2 
                 do ix1=ixMlo1,ixMhi1 
@@ -50,7 +51,7 @@ contains
                    xloc(1:ndim) = ps(igrid)%x(ix1, ix2, ix3, 1:ndim)
 
                    cmaxtot = 0.0d0
-                   !$acc loop seq
+                   ${GPU_LOOP_SEQ()}$
                    do idims = 1, ndim
                       cmax = get_cmax(u, xloc, idims)
                       cmaxtot = cmaxtot + cmax * dxinv(idims)
@@ -79,10 +80,10 @@ contains
     if (need_global_cmax) then
        cmax_mype=-bigdouble
 
-       !$acc parallel loop PRIVATE(igrid) REDUCTION(max:cmax_mype) gang
+       ${GPU_PARALLEL_LOOP_GANG("PRIVATE(igrid) REDUCTION(max:cmax_mype)")}$
        do iigrid=1,igridstail_active; igrid=igrids_active(iigrid)
 
-          !$acc loop vector collapse(ndim) REDUCTION(max:cmax_mype) private(u, xloc)
+          ${GPU_LOOP_VECTOR("collapse(ndim) REDUCTION(max:cmax_mype) private(u, xloc)")}$
           do ix3=ixMlo3,ixMhi3 
              do ix2=ixMlo2,ixMhi2 
                 do ix1=ixMlo1,ixMhi1
@@ -90,7 +91,7 @@ contains
                    u(1:nw_phys) = bg(1)%w(ix1, ix2, ix3, 1:nw_phys, igrid)
                    call to_primitive(u)
                    xloc(1:ndim) = ps(igrid)%x(ix1, ix2, ix3, 1:ndim)
-                   !$acc loop seq
+                   ${GPU_LOOP_SEQ()}$
                    do idims = 1, ndim
                       cmax = get_cmax(u, xloc, idims)
                       cmax_mype = max( cmax_mype, cmax )
@@ -133,7 +134,7 @@ contains
     if (need_global_cmax) then
       call MPI_ALLREDUCE(cmax_mype, cmax_global, 1, MPI_DOUBLE_PRECISION, MPI_MAX, icomm, &
              ierrmpi)
-      !$acc update device(cmax_global)
+      ${GPU_UPDATE_DEVICE('cmax_global')}$
     end if
 
     if(any(dtsave(1:nfile)<bigdouble).or.any(tsave(isavet(1:nfile),&
@@ -158,6 +159,6 @@ contains
        endif
     endif
 
-    !$acc update device(dt)
+    ${GPU_UPDATE_DEVICE('dt')}$
   end subroutine setdt
 end module mod_dt

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -246,8 +246,8 @@ end subroutine finite_volume_local
   !> MUSCL reconstruction in primitive variables for two faces using a 5-point stencil.
   !> Returns uL(:,iface), uR(:,iface) for iface=1 (between cells 2-3) and iface=2 (between 3-4).
   pure subroutine muscl_reconstruct_prim(u, typelim, uL, uR)
-    ${GPU_ROUTINE_SEQ()}$
     use mod_limiter, only: limiter_minmod, limiter_vanleer, limiter_mcbeta, limiter_koren
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys,5)
     integer,  intent(in)  :: typelim
     real(dp), intent(out) :: uL(nw_phys,2), uR(nw_phys,2)

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -121,7 +121,7 @@ end subroutine finite_volume_local
        igrid_beg = (ibatch-1) * max_batch + 1
        igrid_end = min(ibatch * max_batch, igridstail_active)
 
-       ${GPU_PARALLEL_LOOP_GANG("private(inv_dr, dr, n)")}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(inv_dr, dr, n, typelim)")}$ ${GPU_DEFAULT_PRESENT()}$
        do iigrid = igrid_beg, igrid_end
           n = igrids_active(iigrid)
 

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -41,7 +41,7 @@ contains
 
   subroutine finite_volume_local(qdt, dtfactor, ixImin1,ixImin2,&
     ixImin3,ixImax1,ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,&
-    ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
+    ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb)
     use mod_global_parameters
     use mod_comm_lib, only: mpistop
 
@@ -53,10 +53,6 @@ contains
     ! remember, old names map as: wCT => bga, wnew => bgb
     type(block_grid_t)                                    :: bga
     type(block_grid_t)                                    :: bgb
-    double precision, dimension(ixImin1:ixImax1,ixImin2:ixImax2,&
-      ixImin3:ixImax3, 1:nwflux, 1:ndim)  :: fC !not yet provided
-    double precision, dimension(ixImin1:ixImax1,ixImin2:ixImax2,&
-      ixImin3:ixImax3, sdim:3)            :: fE !not yet provided
     ! .. local ..
     integer                :: n, iigrid, ix1,ix2,ix3
     double precision       :: uprim(nw_phys, ixImin1:ixImax1,ixImin2:ixImax2,&
@@ -78,7 +74,7 @@ contains
     case (${method_enum}$)
       call finite_volume_local_${scheme_tag}$(qdt, dtfactor, ixImin1,ixImin2,&
             ixImin3,ixImax1,ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,&
-            ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
+            ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb)
 #:endfor
     case default
       call mpistop("finite_volume_local: unknown flux scheme")
@@ -88,7 +84,7 @@ end subroutine finite_volume_local
 #:def FV_KERNEL(scheme_tag, faceflux_proc)
   subroutine finite_volume_local_${scheme_tag}$(qdt, dtfactor, ixImin1,ixImin2,&
      ixImin3,ixImax1,ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,&
-     ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb, fC, fE)
+     ixOmax3, idimsmin,idimsmax, qtC, bga, qt, bgb)
     use mod_global_parameters
 
     double precision, intent(in)                                       :: qdt,&
@@ -99,10 +95,6 @@ end subroutine finite_volume_local
     ! remember, old names map as: wCT => bga, wnew => bgb
     type(block_grid_t)                                    :: bga
     type(block_grid_t)                                    :: bgb
-    double precision, dimension(ixImin1:ixImax1,ixImin2:ixImax2,&
-       ixImin3:ixImax3, 1:nwflux, 1:ndim)  :: fC !not yet provided
-    double precision, dimension(ixImin1:ixImax1,ixImin2:ixImax2,&
-       ixImin3:ixImax3, sdim:3)            :: fE !not yet provided
     ! .. local ..
     integer                :: n, iigrid, ix1,ix2,ix3
     double precision       :: uprim(nw_phys, ixImin1:ixImax1,ixImin2:ixImax2,&

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -2,6 +2,7 @@
 
 #:mute
 #:include "physics/mod_physics_templates.fpp"
+#:include "mod_gpu_directives.fpp"
 #:endmute
 
 module mod_finite_volume
@@ -126,7 +127,7 @@ end subroutine finite_volume_local
        igrid_beg = (ibatch-1) * max_batch + 1
        igrid_end = min(ibatch * max_batch, igridstail_active)
 
-       !$acc parallel loop gang private(uprim, inv_dr, dr, n) default(present)
+       ${GPU_PARALLEL_LOOP_GANG("private(uprim, inv_dr, dr, n)")}$ ${GPU_DEFAULT_PRESENT()}$
        do iigrid = igrid_beg, igrid_end
           n = igrids_active(iigrid)
 
@@ -134,7 +135,7 @@ end subroutine finite_volume_local
           inv_dr  = 1/dr
           typelim = type_limiter(node(plevel_, n))
 
-          !$acc loop collapse(ndim) vector
+          ${GPU_LOOP_VECTOR("collapse(ndim)")}$
           do ix3=ixImin3,ixImax3 
              do ix2=ixImin2,ixImax2 
                 do ix1=ixImin1,ixImax1 
@@ -145,7 +146,7 @@ end subroutine finite_volume_local
              end do
           end do
 
-       !$acc loop vector collapse(ndim) private(f, wnew, tmp, xlocC, xloc#{if defined('SOURCE_LOCAL')}#, wCT, wprim #{endif}##{if defined('SOURCE_COMPACT')}#, tmp1,tmp2,tmp3 #{endif}#)
+       ${GPU_LOOP_VECTOR("collapse(ndim) private(f, wnew, tmp, xlocC, xloc" + (", wCT, wprim " if defined('SOURCE_LOCAL') else "") + (", tmp1,tmp2,tmp3 " if defined('SOURCE_COMPACT') else "") + ")")}$
        do ix3=ixOmin3,ixOmax3 
           do ix2=ixOmin2,ixOmax2 
              do ix1=ixOmin1,ixOmax1 
@@ -245,7 +246,7 @@ end subroutine finite_volume_local
   !> MUSCL reconstruction in primitive variables for two faces using a 5-point stencil.
   !> Returns uL(:,iface), uR(:,iface) for iface=1 (between cells 2-3) and iface=2 (between 3-4).
   pure subroutine muscl_reconstruct_prim(u, typelim, uL, uR)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_limiter, only: limiter_minmod, limiter_vanleer, limiter_mcbeta, limiter_koren
     real(dp), intent(in)  :: u(nw_phys,5)
     integer,  intent(in)  :: typelim
@@ -300,7 +301,7 @@ end subroutine finite_volume_local
   !> One-face LLF/Rusanov numerical flux from primitive L/R states.
   !> phi(nw_flux) is the adaptive-diffusion reduction factor; only present when FLUX_AD is defined.
   subroutine riemann_llf_prim(uL, uR, xC, flux_dim, F#{if defined('FLUX_AD')}#, phi#{endif}#)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: uL(nw_phys), uR(nw_phys)
     real(dp), intent(in)    :: xC(ndim)
     integer,  intent(in)    :: flux_dim
@@ -329,7 +330,7 @@ end subroutine finite_volume_local
   !> One-face HLL numerical flux from primitive L/R states.
   !> takes flux_type(flux_dim,nw_flux) into account (fallback to LLF for selected variables)
   subroutine riemann_hll_prim(uL, uR, xC, flux_dim, F)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: uL(nw_phys), uR(nw_phys)
     real(dp), intent(in)    :: xC(ndim)
     integer,  intent(in)    :: flux_dim
@@ -379,7 +380,7 @@ end subroutine finite_volume_local
   !> Reference: Toro (2010), chapter 10 (Variant 2)
   !> does not yet take flux_type(flux_dim,nw_flux) into account
   subroutine riemann_hllc_prim(uL, uR, xC, flux_dim, F)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: uL(nw_phys), uR(nw_phys)
     real(dp), intent(in)    :: xC(ndim)
     integer,  intent(in)    :: flux_dim
@@ -463,7 +464,7 @@ end subroutine finite_volume_local
   !> MUSCL (primitive-variable) reconstruction with slope limiter; HLL two-wave approximate Riemann flux at faces.
   !> Uses estimated left/right signal speeds (Davis (1988)) for less diffusion than LLF, no contact resolution.
   subroutine reconflux_muscl_hll_prim(u, xlocC, flux_dim, flux, typelim)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys, 5)
     real(dp), intent(in)  :: xlocC(1:ndim, 2)
     integer, intent(in)   :: flux_dim, typelim
@@ -484,7 +485,7 @@ end subroutine finite_volume_local
   !> Robust and diffusive; uses local max wavespeed for upwinding.
   !> Adaptive diffusion (Rempel et al. 2009) is compiled in only when FLUX_AD is defined.
   subroutine reconflux_muscl_llf_prim(u, xlocC, flux_dim, flux, typelim)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys, 5)
     real(dp), intent(in)  :: xlocC(1:ndim, 2)
     integer, intent(in)   :: flux_dim, typelim
@@ -536,7 +537,7 @@ end subroutine finite_volume_local
   !> MUSCL (primitive-variable) reconstruction with slope limiter; HLLC approximate Riemann flux at faces.
   !> Restores the contact wave (and shear in Euler/HD), typically sharper than HLL for similar cost.
   subroutine reconflux_muscl_hllc_prim(u, xlocC, flux_dim, flux, typelim)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys, 5)
     real(dp), intent(in)  :: xlocC(1:ndim, 2)
     integer, intent(in)   :: flux_dim, typelim
@@ -553,7 +554,7 @@ end subroutine finite_volume_local
 
 
   pure real(dp) function vanleer(a, b) result(phi)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in) :: a, b
     real(dp)             :: ab
 
@@ -566,7 +567,7 @@ end subroutine finite_volume_local
   end function vanleer
 
   pure real(dp) function minmod(a, b)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in) :: a, b
 
     if (a * b <= 0) then
@@ -584,7 +585,7 @@ end subroutine finite_volume_local
   !> have r = a / b (ratio of gradients). Then the limiter phi(r) is multiplied
   !> with b. With this implementation, you get phi(r) * b
   pure real(dp) function koren(a, b)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in) :: a  !< Density gradient (numerator)
     real(dp), intent(in) :: b  !< Density gradient (denominator)
     real(dp), parameter  :: third = 1/3.0_dp
@@ -613,7 +614,7 @@ end subroutine finite_volume_local
   !> Monotonised central-difference limiter with tunable beta (AMRVAC's
   !> mcbeta; beta=2 recovers the classic MC limiter, van Leer 1979)
   pure real(dp) function mcbeta(a, b) result(phi)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in) :: a, b
   real(dp), parameter  :: c_mcbeta = 1.4_dp
   real(dp)             :: ab

--- a/src/mod_finite_volume.fpp
+++ b/src/mod_finite_volume.fpp
@@ -97,8 +97,6 @@ end subroutine finite_volume_local
     type(block_grid_t)                                    :: bgb
     ! .. local ..
     integer                :: n, iigrid, ix1,ix2,ix3
-    double precision       :: uprim(nw_phys, ixImin1:ixImax1,ixImin2:ixImax2,&
-       ixImin3:ixImax3)
     real(dp)               :: tmp(nw_phys,5)
     real(dp)               :: tmp1(nw_phys,3),tmp2(nw_phys,3),tmp3(nw_phys,3)
     real(dp)               :: f(nw_flux, 2)
@@ -110,7 +108,11 @@ end subroutine finite_volume_local
     real(dp)               :: wprim(nw_phys), wCT(nw_phys), wnew(nw_phys)
     integer, parameter     :: max_batch=4096
     integer                :: nbatches, ibatch, igrid_beg, igrid_end
+    double precision       :: uprim(nw_phys, ixImin1:ixImax1,ixImin2:ixImax2,&
+       ixImin3:ixImax3, max_batch)
     !-----------------------------------------------------------------------------
+
+    ${GPU_ENTER_DATA_CREATE("uprim")}$
 
     ! batch-launch the kernels (oom issue when many ~30000 blocks):
     nbatches = (igridstail_active + max_batch - 1) / max_batch ! ceiling division
@@ -119,7 +121,7 @@ end subroutine finite_volume_local
        igrid_beg = (ibatch-1) * max_batch + 1
        igrid_end = min(ibatch * max_batch, igridstail_active)
 
-       ${GPU_PARALLEL_LOOP_GANG("private(uprim, inv_dr, dr, n)")}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(inv_dr, dr, n)")}$ ${GPU_DEFAULT_PRESENT()}$
        do iigrid = igrid_beg, igrid_end
           n = igrids_active(iigrid)
 
@@ -132,8 +134,8 @@ end subroutine finite_volume_local
              do ix2=ixImin2,ixImax2 
                 do ix1=ixImin1,ixImax1 
                    ! Convert to primitive
-                   uprim(1:nw_phys, ix1,ix2,ix3) = bga%w(ix1,ix2,ix3, 1:nw_phys, n)
-                   call to_primitive(uprim(1:nw_phys, ix1,ix2,ix3))
+                   uprim(1:nw_phys, ix1,ix2,ix3, iigrid - igrid_beg + 1) = bga%w(ix1,ix2,ix3, 1:nw_phys, n)
+                   call to_primitive(uprim(1:nw_phys, ix1,ix2,ix3, iigrid - igrid_beg + 1))
                 end do
              end do
           end do
@@ -144,7 +146,7 @@ end subroutine finite_volume_local
              do ix1=ixOmin1,ixOmax1 
                 ! Compute fluxes in all dimensions
 
-                tmp = uprim(1:nw_phys, ix1-2:ix1+2, ix2, ix3)
+                tmp = uprim(1:nw_phys, ix1-2:ix1+2, ix2, ix3, iigrid - igrid_beg + 1)
                 xlocC(1:ndim,1) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(1:ndim,2) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(1,1) = xlocC(1,1)-0.5_dp*dr(1)
@@ -153,7 +155,7 @@ end subroutine finite_volume_local
                 bgb%w(ix1, ix2, ix3, 1:nw_flux, n) = bgb%w(ix1, ix2, ix3, 1:nw_flux,&
                      n) + qdt * (f(:, 1) - f(:, 2)) * inv_dr(1)
 
-                tmp = uprim(1:nw_phys, ix1, ix2-2:ix2+2, ix3)
+                tmp = uprim(1:nw_phys, ix1, ix2-2:ix2+2, ix3, iigrid - igrid_beg + 1)
                 xlocC(1:ndim,1) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(1:ndim,2) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(2,1) = xlocC(2,1)-0.5_dp*dr(2)
@@ -162,7 +164,7 @@ end subroutine finite_volume_local
                 bgb%w(ix1, ix2, ix3, 1:nw_flux, n) = bgb%w(ix1, ix2, ix3, 1:nw_flux,&
                      n) + qdt * (f(:, 1) - f(:, 2)) * inv_dr(2)
 
-                tmp = uprim(1:nw_phys, ix1, ix2, ix3-2:ix3+2)
+                tmp = uprim(1:nw_phys, ix1, ix2, ix3-2:ix3+2, iigrid - igrid_beg + 1)
                 xlocC(1:ndim,1) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(1:ndim,2) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                 xlocC(3,1) = xlocC(3,1)-0.5_dp*dr(3)
@@ -174,7 +176,7 @@ end subroutine finite_volume_local
 #:if defined('SOURCE_LOCAL')
                    ! Add local source terms:
                    xloc(1:ndim) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
-                   wprim        = uprim(1:nw_phys, ix1, ix2, ix3)
+                   wprim        = uprim(1:nw_phys, ix1, ix2, ix3, iigrid - igrid_beg + 1)
                    wCT          = bga%w(ix1, ix2, ix3, 1:nw_phys, n)
                    wnew         = bgb%w(ix1, ix2, ix3, 1:nw_phys, n)
                    call addsource_local(qdt*dble(idimsmax-idimsmin+1)/dble(ndim),&
@@ -188,17 +190,17 @@ end subroutine finite_volume_local
                    xloc(1:ndim) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                    wnew         = bgb%w(ix1, ix2, ix3, 1:nw_phys, n)
 
-                   tmp = uprim(1:nw_phys, ix1-2:ix1+2, ix2, ix3)
+                   tmp = uprim(1:nw_phys, ix1-2:ix1+2, ix2, ix3, iigrid - igrid_beg + 1)
                    call addsource_nonlocal(qdt*dble(idimsmax-idimsmin+1)/dble(ndim),&
                         dtfactor*dble(idimsmax-idimsmin+1)/dble(ndim), qtC, tmp,&
                         qt, wnew, xloc, dr, 1, .false. )
 
-                   tmp = uprim(1:nw_phys, ix1, ix2-2:ix2+2, ix3)
+                   tmp = uprim(1:nw_phys, ix1, ix2-2:ix2+2, ix3, iigrid - igrid_beg + 1)
                    call addsource_nonlocal(qdt*dble(idimsmax-idimsmin+1)/dble(ndim),&
                         dtfactor*dble(idimsmax-idimsmin+1)/dble(ndim), qtC, tmp,&
                         qt, wnew, xloc, dr, 2, .false. )
 
-                   tmp = uprim(1:nw_phys, ix1, ix2, ix3-2:ix3+2)
+                   tmp = uprim(1:nw_phys, ix1, ix2, ix3-2:ix3+2, iigrid - igrid_beg + 1)
                    call addsource_nonlocal(qdt*dble(idimsmax-idimsmin+1)/dble(ndim),&
                         dtfactor*dble(idimsmax-idimsmin+1)/dble(ndim), qtC, tmp,&
                         qt, wnew, xloc, dr, 3, .false. )
@@ -210,9 +212,9 @@ end subroutine finite_volume_local
                    ! Add non-local compact source terms:
                    xloc(1:ndim) = ps(n)%x(ix1, ix2, ix3, 1:ndim)
                    wnew         = bgb%w(ix1, ix2, ix3, 1:nw_phys, n)
-                   tmp1 = uprim(1:nw_phys, ix1-1:ix1+1, ix2, ix3)
-                   tmp2 = uprim(1:nw_phys, ix1, ix2-1:ix2+1, ix3)
-                   tmp3 = uprim(1:nw_phys, ix1, ix2, ix3-1:ix3+1)
+                   tmp1 = uprim(1:nw_phys, ix1-1:ix1+1, ix2, ix3, iigrid - igrid_beg + 1)
+                   tmp2 = uprim(1:nw_phys, ix1, ix2-1:ix2+1, ix3, iigrid - igrid_beg + 1)
+                   tmp3 = uprim(1:nw_phys, ix1, ix2, ix3-1:ix3+1, iigrid - igrid_beg + 1)
                    call addsource_compact(qdt*dble(idimsmax-idimsmin+1)/dble(ndim),&
                         dtfactor*dble(idimsmax-idimsmin+1)/dble(ndim), qtC, tmp1,tmp2,tmp3, &
                         qt, wnew, xloc, dr, .false. )
@@ -224,6 +226,7 @@ end subroutine finite_volume_local
           end do
        end do
     end do
+    ${GPU_EXIT_DATA_DELETE("uprim")}$
 
   end subroutine finite_volume_local_${scheme_tag}$
   #:enddef

--- a/src/mod_functions_connectivity.fpp
+++ b/src/mod_functions_connectivity.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 module mod_functions_connectivity
 
 

--- a/src/mod_functions_connectivity.fpp
+++ b/src/mod_functions_connectivity.fpp
@@ -118,17 +118,17 @@ module mod_functions_connectivity
 #endif
 #ifdef _OPENMP
     if (omp_target_is_present(c_loc(nbprocs_info%srl_nb), omp_get_default_device()) /= 0) then
-      !omp target exit data delete (nbprocs_info%srl_nb)
+      !$omp target exit data map(delete:nbprocs_info%srl_nb)
     end if
     if (omp_target_is_present(c_loc(nbprocs_info%course_nb), omp_get_default_device()) /= 0) then
-      !omp target exit data delete (nbprocs_info%course_nb)
+      !$omp target exit data map(delete:nbprocs_info%course_nb)
     end if
     if (omp_target_is_present(c_loc(nbprocs_info%fine_nb), omp_get_default_device()) /= 0) then
-      !omp target exit data delete (nbprocs_info%fine_nb)
+      !$omp target exit data map(delete:nbprocs_info%fine_nb)
     end if
 #ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
     if (omp_target_is_present(c_loc(nbprocs_info))) then
-      !$omp target exit data delete (nbprocs_info)
+      !$omp target exit data map(delete:nbprocs_info)
     end if
 #endif
 #ifndef _CRAYFTN ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)

--- a/src/mod_functions_connectivity.fpp
+++ b/src/mod_functions_connectivity.fpp
@@ -127,7 +127,7 @@ module mod_functions_connectivity
       !$omp target exit data map(delete:nbprocs_info%fine_nb)
     end if
 #ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
-    if (omp_target_is_present(c_loc(nbprocs_info))) then
+    if (omp_target_is_present(c_loc(nbprocs_info), omp_get_default_device()) /= 0) then
       !$omp target exit data map(delete:nbprocs_info)
     end if
 #endif

--- a/src/mod_functions_connectivity.fpp
+++ b/src/mod_functions_connectivity.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 module mod_functions_connectivity
 
 
@@ -49,7 +50,7 @@ module mod_functions_connectivity
     end do
 
     igridstail=iigrid
-    !$acc update device(igrids, igridstail)
+    ${GPU_UPDATE_DEVICE('igrids, igridstail')}$
 
   end subroutine getigrids
 
@@ -59,7 +60,11 @@ module mod_functions_connectivity
     use mod_ghostcells_update
 #ifdef _OPENACC
     use openacc, only: acc_is_present
-#endif    
+#endif
+#ifdef _OPENMP
+    use omp_lib, only: omp_target_is_present, omp_get_default_device
+    use, intrinsic :: iso_c_binding, only: c_loc
+#endif
     use mod_amr_neighbors, only: find_neighbor
 
     integer :: iigrid, igrid, i1,i2,i3, my_neighbor_type
@@ -86,59 +91,45 @@ module mod_functions_connectivity
     if(stagger_grid) nrecv_cc=0; nsend_cc=0
     
     
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(_OPENMP)
     do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc exit data delete( nbprocs_info%srl_nb(inb)%rcv%buffer,      &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info_rcv%buffer, &
-       !$acc&                    nbprocs_info%srl_nb(inb)%send%buffer,     &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info_send%buffer, &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info%nigrids,    &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info%igrid,      &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info%iencode,    &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info%ibuf_start, &
-       !$acc&                    nbprocs_info%srl_nb(inb)%info%isize )
+       ${GPU_EXIT_DATA_DELETE('nbprocs_info%srl_nb(inb)%rcv%buffer, nbprocs_info%srl_nb(inb)%info_rcv%buffer, nbprocs_info%srl_nb(inb)%send%buffer, nbprocs_info%srl_nb(inb)%info_send%buffer, nbprocs_info%srl_nb(inb)%info%nigrids, nbprocs_info%srl_nb(inb)%info%igrid, nbprocs_info%srl_nb(inb)%info%iencode, nbprocs_info%srl_nb(inb)%info%ibuf_start, nbprocs_info%srl_nb(inb)%info%isize')}$
     end do
 
     do inb = 1, nbprocs_info%nbprocs_c
-       !$acc exit data delete( nbprocs_info%course_nb(inb)%rcv%buffer,      &
-       !$acc&                    nbprocs_info%course_nb(inb)%info_rcv%buffer, &
-       !$acc&                    nbprocs_info%course_nb(inb)%send%buffer,     &
-       !$acc&                    nbprocs_info%course_nb(inb)%info_send%buffer, &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%nigrids,    &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%igrid,      &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%inc1,       &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%inc2,       &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%inc3,       &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%i1,         &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%i2,         &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%i3,         &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%ibuf_start, &
-       !$acc&                    nbprocs_info%course_nb(inb)%info%isize )
+       ${GPU_EXIT_DATA_DELETE('nbprocs_info%course_nb(inb)%rcv%buffer, nbprocs_info%course_nb(inb)%info_rcv%buffer, nbprocs_info%course_nb(inb)%send%buffer, nbprocs_info%course_nb(inb)%info_send%buffer, nbprocs_info%course_nb(inb)%info%nigrids, nbprocs_info%course_nb(inb)%info%igrid, nbprocs_info%course_nb(inb)%info%inc1, nbprocs_info%course_nb(inb)%info%inc2, nbprocs_info%course_nb(inb)%info%inc3, nbprocs_info%course_nb(inb)%info%i1, nbprocs_info%course_nb(inb)%info%i2, nbprocs_info%course_nb(inb)%info%i3, nbprocs_info%course_nb(inb)%info%ibuf_start, nbprocs_info%course_nb(inb)%info%isize')}$
     end do
 
     do inb = 1, nbprocs_info%nbprocs_f
-       !$acc exit data delete( nbprocs_info%fine_nb(inb)%rcv%buffer,      &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info_rcv%buffer, &
-       !$acc&                    nbprocs_info%fine_nb(inb)%send%buffer,     &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info_send%buffer, &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%nigrids,    &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%igrid,      &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%inc1,       &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%inc2,       &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%inc3,       &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%i1,         &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%i2,         &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%i3,         &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%ibuf_start, &
-       !$acc&                    nbprocs_info%fine_nb(inb)%info%isize )
+       ${GPU_EXIT_DATA_DELETE('nbprocs_info%fine_nb(inb)%rcv%buffer, nbprocs_info%fine_nb(inb)%info_rcv%buffer, nbprocs_info%fine_nb(inb)%send%buffer, nbprocs_info%fine_nb(inb)%info_send%buffer, nbprocs_info%fine_nb(inb)%info%nigrids, nbprocs_info%fine_nb(inb)%info%igrid, nbprocs_info%fine_nb(inb)%info%inc1, nbprocs_info%fine_nb(inb)%info%inc2, nbprocs_info%fine_nb(inb)%info%inc3, nbprocs_info%fine_nb(inb)%info%i1, nbprocs_info%fine_nb(inb)%info%i2, nbprocs_info%fine_nb(inb)%info%i3, nbprocs_info%fine_nb(inb)%info%ibuf_start, nbprocs_info%fine_nb(inb)%info%isize')}$
     end do
-
+#endif
     ! Deallocate the top-level objects
+#ifdef _OPENACC
     !$acc exit data delete (nbprocs_info%srl_nb) if(acc_is_present(nbprocs_info%srl_nb))
     !$acc exit data delete (nbprocs_info%course_nb) if(acc_is_present(nbprocs_info%course_nb))
     !$acc exit data delete (nbprocs_info%fine_nb) if(acc_is_present(nbprocs_info%fine_nb))
 #ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
     !$acc exit data delete (nbprocs_info) if(acc_is_present(nbprocs_info))
+#endif
+#ifndef _CRAYFTN ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)
+    !$acc exit data delete (nbprocs_info)
+#endif
+#endif
+#ifdef _OPENMP
+    if (omp_target_is_present(c_loc(nbprocs_info%srl_nb), omp_get_default_device()) /= 0) then
+      !omp target exit data delete (nbprocs_info%srl_nb)
+    end if
+    if (omp_target_is_present(c_loc(nbprocs_info%course_nb), omp_get_default_device()) /= 0) then
+      !omp target exit data delete (nbprocs_info%course_nb)
+    end if
+    if (omp_target_is_present(c_loc(nbprocs_info%fine_nb), omp_get_default_device()) /= 0) then
+      !omp target exit data delete (nbprocs_info%fine_nb)
+    end if
+#ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
+    if (omp_target_is_present(c_loc(nbprocs_info))) then
+      !$omp target exit data delete (nbprocs_info)
+    end if
 #endif
 #ifndef _CRAYFTN ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)
     !$acc exit data delete (nbprocs_info)
@@ -662,60 +653,29 @@ module mod_functions_connectivity
     
     
     !update the neighbor information on the device
-    !$acc update device(neighbor, neighbor_type, neighbor_pole, neighbor_child, idphyb)
-    
-    !$acc enter data copyin (nbprocs_info)
-    !$acc enter data copyin (nbprocs_info%srl_nb, nbprocs_info%course_nb, nbprocs_info%fine_nb)
-#ifdef _OPENACC
-    do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc enter data create( nbprocs_info%srl_nb(inb)%rcv%buffer, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%send%buffer, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info_rcv%buffer, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info_send%buffer )
+    ${GPU_UPDATE_DEVICE('neighbor, neighbor_type, neighbor_pole, neighbor_child, idphyb')}$
 
-       !$acc enter data copyin( nbprocs_info%srl_nb(inb)%info%nigrids, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info%igrid, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info%iencode, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info%ibuf_start, &
-       !$acc&                   nbprocs_info%srl_nb(inb)%info%isize )
+    ${GPU_ENTER_DATA_COPYIN('nbprocs_info')}$
+    ${GPU_ENTER_DATA_COPYIN('nbprocs_info%srl_nb, nbprocs_info%course_nb, nbprocs_info%fine_nb')}$
+#if defined(_OPENACC) || defined(_OPENMP)
+    do inb = 1, nbprocs_info%nbprocs_srl
+       ${GPU_ENTER_DATA_CREATE('nbprocs_info%srl_nb(inb)%rcv%buffer, nbprocs_info%srl_nb(inb)%send%buffer, nbprocs_info%srl_nb(inb)%info_rcv%buffer, nbprocs_info%srl_nb(inb)%info_send%buffer')}$
+
+       ${GPU_ENTER_DATA_COPYIN('nbprocs_info%srl_nb(inb)%info%nigrids, nbprocs_info%srl_nb(inb)%info%igrid, nbprocs_info%srl_nb(inb)%info%iencode, nbprocs_info%srl_nb(inb)%info%ibuf_start, nbprocs_info%srl_nb(inb)%info%isize')}$
     end do
 
     do inb = 1, nbprocs_info%nbprocs_c
-       !$acc enter data create( nbprocs_info%course_nb(inb)%rcv%buffer, &
-       !$acc&                   nbprocs_info%course_nb(inb)%send%buffer, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info_rcv%buffer, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info_send%buffer )
+       ${GPU_ENTER_DATA_CREATE('nbprocs_info%course_nb(inb)%rcv%buffer, nbprocs_info%course_nb(inb)%send%buffer, nbprocs_info%course_nb(inb)%info_rcv%buffer, nbprocs_info%course_nb(inb)%info_send%buffer')}$
 
-       !$acc enter data copyin( nbprocs_info%course_nb(inb)%info%nigrids, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%igrid, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%inc1, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%inc2, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%inc3, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%i1, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%i2, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%i3, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%ibuf_start, &
-       !$acc&                   nbprocs_info%course_nb(inb)%info%isize )
+       ${GPU_ENTER_DATA_COPYIN('nbprocs_info%course_nb(inb)%info%nigrids, nbprocs_info%course_nb(inb)%info%igrid, nbprocs_info%course_nb(inb)%info%inc1, nbprocs_info%course_nb(inb)%info%inc2, nbprocs_info%course_nb(inb)%info%inc3, nbprocs_info%course_nb(inb)%info%i1, nbprocs_info%course_nb(inb)%info%i2, nbprocs_info%course_nb(inb)%info%i3, nbprocs_info%course_nb(inb)%info%ibuf_start, nbprocs_info%course_nb(inb)%info%isize')}$
     end do
 
     do inb = 1, nbprocs_info%nbprocs_f
-       !$acc enter data create( nbprocs_info%fine_nb(inb)%rcv%buffer, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%send%buffer, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info_rcv%buffer, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info_send%buffer )
+       ${GPU_ENTER_DATA_CREATE('nbprocs_info%fine_nb(inb)%rcv%buffer, nbprocs_info%fine_nb(inb)%send%buffer, nbprocs_info%fine_nb(inb)%info_rcv%buffer, nbprocs_info%fine_nb(inb)%info_send%buffer')}$
 
-       !$acc enter data copyin( nbprocs_info%fine_nb(inb)%info%nigrids, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%igrid, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%inc1, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%inc2, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%inc3, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%i1, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%i2, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%i3, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%ibuf_start, &
-       !$acc&                   nbprocs_info%fine_nb(inb)%info%isize )
+       ${GPU_ENTER_DATA_COPYIN('nbprocs_info%fine_nb(inb)%info%nigrids, nbprocs_info%fine_nb(inb)%info%igrid, nbprocs_info%fine_nb(inb)%info%inc1, nbprocs_info%fine_nb(inb)%info%inc2, nbprocs_info%fine_nb(inb)%info%inc3, nbprocs_info%fine_nb(inb)%info%i1, nbprocs_info%fine_nb(inb)%info%i2, nbprocs_info%fine_nb(inb)%info%i3, nbprocs_info%fine_nb(inb)%info%ibuf_start, nbprocs_info%fine_nb(inb)%info%isize')}$
     end do
-#endif 
+#endif
 
   end subroutine build_connectivity
 

--- a/src/mod_functions_connectivity.fpp
+++ b/src/mod_functions_connectivity.fpp
@@ -58,14 +58,8 @@ module mod_functions_connectivity
     use mod_forest
     use mod_global_parameters
     use mod_ghostcells_update
-#ifdef _OPENACC
-    use openacc, only: acc_is_present
-#endif
-#ifdef _OPENMP
-    use omp_lib, only: omp_target_is_present, omp_get_default_device
-    use, intrinsic :: iso_c_binding, only: c_loc
-#endif
     use mod_amr_neighbors, only: find_neighbor
+    ${GPU_USE_IS_PRESENT()}$
 
     integer :: iigrid, igrid, i1,i2,i3, my_neighbor_type
     integer :: iside, idim, ic1,ic2,ic3, inc1,inc2,inc3, ih1,ih2,ih3, icdim
@@ -103,36 +97,17 @@ module mod_functions_connectivity
     do inb = 1, nbprocs_info%nbprocs_f
        ${GPU_EXIT_DATA_DELETE('nbprocs_info%fine_nb(inb)%rcv%buffer, nbprocs_info%fine_nb(inb)%info_rcv%buffer, nbprocs_info%fine_nb(inb)%send%buffer, nbprocs_info%fine_nb(inb)%info_send%buffer, nbprocs_info%fine_nb(inb)%info%nigrids, nbprocs_info%fine_nb(inb)%info%igrid, nbprocs_info%fine_nb(inb)%info%inc1, nbprocs_info%fine_nb(inb)%info%inc2, nbprocs_info%fine_nb(inb)%info%inc3, nbprocs_info%fine_nb(inb)%info%i1, nbprocs_info%fine_nb(inb)%info%i2, nbprocs_info%fine_nb(inb)%info%i3, nbprocs_info%fine_nb(inb)%info%ibuf_start, nbprocs_info%fine_nb(inb)%info%isize')}$
     end do
-#endif
+
     ! Deallocate the top-level objects
-#ifdef _OPENACC
-    !$acc exit data delete (nbprocs_info%srl_nb) if(acc_is_present(nbprocs_info%srl_nb))
-    !$acc exit data delete (nbprocs_info%course_nb) if(acc_is_present(nbprocs_info%course_nb))
-    !$acc exit data delete (nbprocs_info%fine_nb) if(acc_is_present(nbprocs_info%fine_nb))
-#ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
-    !$acc exit data delete (nbprocs_info) if(acc_is_present(nbprocs_info))
-#endif
-#ifndef _CRAYFTN ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)
-    !$acc exit data delete (nbprocs_info)
-#endif
-#endif
-#ifdef _OPENMP
-    if (omp_target_is_present(c_loc(nbprocs_info%srl_nb), omp_get_default_device()) /= 0) then
-      !$omp target exit data map(delete:nbprocs_info%srl_nb)
-    end if
-    if (omp_target_is_present(c_loc(nbprocs_info%course_nb), omp_get_default_device()) /= 0) then
-      !$omp target exit data map(delete:nbprocs_info%course_nb)
-    end if
-    if (omp_target_is_present(c_loc(nbprocs_info%fine_nb), omp_get_default_device()) /= 0) then
-      !$omp target exit data map(delete:nbprocs_info%fine_nb)
-    end if
-#ifdef _CRAYFTN ! should be a no-op, but hey, its cray...
-    if (omp_target_is_present(c_loc(nbprocs_info), omp_get_default_device()) /= 0) then
-      !$omp target exit data map(delete:nbprocs_info)
-    end if
-#endif
-#ifndef _CRAYFTN ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)
-    !$acc exit data delete (nbprocs_info)
+    ${GPU_EXIT_DATA_DELETE_IF_PRESENT('nbprocs_info%srl_nb')}$
+    ${GPU_EXIT_DATA_DELETE_IF_PRESENT('nbprocs_info%course_nb')}$
+    ${GPU_EXIT_DATA_DELETE_IF_PRESENT('nbprocs_info%fine_nb')}$
+#ifdef _CRAYFTN
+    ! should be a no-op, but hey, its cray...
+    ${GPU_EXIT_DATA_DELETE_IF_PRESENT('nbprocs_info')}$
+#else
+    ! acc_is_present can only be cast on arrays with nvidia (its anyways a no-op)  
+    ${GPU_EXIT_DATA_DELETE('nbprocs_info')}$
 #endif
 #endif
 

--- a/src/mod_geometry.fpp
+++ b/src/mod_geometry.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> Module with geometry-related routines (e.g., divergence, curl)
 module mod_geometry
   use mod_comm_lib, only: mpistop

--- a/src/mod_geometry.fpp
+++ b/src/mod_geometry.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> Module with geometry-related routines (e.g., divergence, curl)
 module mod_geometry
   use mod_comm_lib, only: mpistop
@@ -5,7 +6,7 @@ module mod_geometry
   public
 
   integer :: coordinate=-1
-  !$acc declare copyin(coordinate)
+  ${GPU_DECLARE_COPYIN('coordinate')}$
   integer, parameter :: Cartesian          = 0
   integer, parameter :: Cartesian_stretched= 1
   integer, parameter :: cylindrical        = 2
@@ -13,7 +14,7 @@ module mod_geometry
   integer, parameter :: Cartesian_expansion= 4
 
   integer :: type_curl=0
-  !$acc declare copyin(type_curl)
+  ${GPU_DECLARE_COPYIN('type_curl')}$
   integer, parameter :: central=1
   integer, parameter :: Gaussbased=2
   integer, parameter :: Stokesbased=3

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1906,9 +1906,9 @@ contains
 
 
   subroutine fill_coarse_boundary(time,igrid,i1,i2,i3)
-    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
+    ${GPU_ROUTINE_VECTOR()}$
     integer, intent(in) :: igrid,i1,i2,i3
     double precision, intent(in) :: time
 
@@ -1982,9 +1982,9 @@ contains
 
   !> Physical boundary conditions
   subroutine fill_boundary_before_gc(s,igrid,time,qdt)
-    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
+    ${GPU_ROUTINE_VECTOR()}$
 
     type(state), intent(inout) :: s
     integer, intent(in) :: igrid
@@ -2045,9 +2045,9 @@ contains
 
   !> Physical boundary conditions
   subroutine fill_boundary_after_gc(s,igrid,time,qdt)
-    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
+    ${GPU_ROUTINE_VECTOR()}$
 
     type(state), intent(inout) :: s
     integer, intent(in) :: igrid

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 #ifdef _CRAYFTN
 ! locally switch off gpudirect since it does not work reliably with the nested datastructures on LUMI
 #ifndef NOGPUDIRECT
@@ -21,19 +22,19 @@ module mod_ghostcells_update
 
   ! A switch of update physical boundary or not
   logical, public :: bcphys=.true.
-  !$acc declare copyin(bcphys)
+  ${GPU_DECLARE_COPYIN('bcphys')}$
 
   integer :: ixMmin1,ixMmin2,ixMmin3,ixMmax1,ixMmax2,ixMmax3, ixCoGmin1,&
        ixCoGmin2,ixCoGmin3,ixCoGmax1,ixCoGmax2,ixCoGmax3, ixCoMmin1,ixCoMmin2,&
        ixCoMmin3,ixCoMmax1,ixCoMmax2,ixCoMmax3, ixCoGsmin1,ixCoGsmin2,ixCoGsmin3,&
        ixCoGsmax1,ixCoGsmax2,ixCoGsmax3
-  !$acc declare create(ixCoGmin1,ixCoGmin2,ixCoGmin3,ixCoGmax1,ixCoGmax2,ixCoGmax3)
-  !$acc declare create(ixMmin1,ixMmin2,ixMmin3,ixMmax1,ixMmax2,ixMmax3)
-  !$acc declare create(ixCoMmin1,ixCoMmin2,ixCoMmin3,ixCoMmax1,ixCoMmax2,ixCoMmax3)
-  !$acc declare create(ixCoGsmin1,ixCoGsmin2,ixCoGsmin3,ixCoGsmax1,ixCoGsmax2,ixCoGsmax3)
+  ${GPU_DECLARE_CREATE('ixCoGmin1,ixCoGmin2,ixCoGmin3,ixCoGmax1,ixCoGmax2,ixCoGmax3')}$
+  ${GPU_DECLARE_CREATE('ixMmin1,ixMmin2,ixMmin3,ixMmax1,ixMmax2,ixMmax3')}$
+  ${GPU_DECLARE_CREATE('ixCoMmin1,ixCoMmin2,ixCoMmin3,ixCoMmax1,ixCoMmax2,ixCoMmax3')}$
+  ${GPU_DECLARE_CREATE('ixCoGsmin1,ixCoGsmin2,ixCoGsmin3,ixCoGsmax1,ixCoGsmax2,ixCoGsmax3')}$
 
   logical  :: req_diagonal = .true.
-  !$acc declare copyin(req_diagonal)
+  ${GPU_DECLARE_COPYIN('req_diagonal')}$
 
 
   ! The first index goes from -1:2, where -1 is used when a block touches the
@@ -45,9 +46,9 @@ module mod_ghostcells_update
   integer, dimension(-1:2,-1:1) :: ixS_srl_min1,ixS_srl_min2,ixS_srl_min3,&
        ixS_srl_max1,ixS_srl_max2,ixS_srl_max3, ixR_srl_min1,ixR_srl_min2,&
        ixR_srl_min3,ixR_srl_max1,ixR_srl_max2,ixR_srl_max3
-  !$acc declare create(ixS_srl_min1,ixS_srl_min2,ixS_srl_min3)
-  !$acc declare create(ixS_srl_max1,ixS_srl_max2,ixS_srl_max3, ixR_srl_min1,ixR_srl_min2)
-  !$acc declare create(ixR_srl_min3,ixR_srl_max1,ixR_srl_max2,ixR_srl_max3)
+  ${GPU_DECLARE_CREATE('ixS_srl_min1,ixS_srl_min2,ixS_srl_min3')}$
+  ${GPU_DECLARE_CREATE('ixS_srl_max1,ixS_srl_max2,ixS_srl_max3, ixR_srl_min1,ixR_srl_min2')}$
+  ${GPU_DECLARE_CREATE('ixR_srl_min3,ixR_srl_max1,ixR_srl_max2,ixR_srl_max3')}$
 
   ! index ranges of staggered variables to send (S) to sibling blocks, receive (R) from sibling blocks
   integer, dimension(3,-1:1) :: ixS_srl_stg_min1,ixS_srl_stg_min2,&
@@ -58,7 +59,7 @@ module mod_ghostcells_update
   ! index ranges to send (S) restricted (r) ghost cells to coarser blocks
   integer, dimension(-1:1,-1:1) :: ixS_r_min1,ixS_r_min2,ixS_r_min3,ixS_r_max1,&
        ixS_r_max2,ixS_r_max3
-  !$acc declare create(ixS_r_min1,ixS_r_min2,ixS_r_min3,ixS_r_max1,ixS_r_max2,ixS_r_max3)
+  ${GPU_DECLARE_CREATE('ixS_r_min1,ixS_r_min2,ixS_r_min3,ixS_r_max1,ixS_r_max2,ixS_r_max3')}$
 
   ! index ranges of staggered variables to send (S) restricted (r) ghost cells to coarser blocks
   integer, dimension(3,-1:1) :: ixS_r_stg_min1,ixS_r_stg_min2,ixS_r_stg_min3,&
@@ -67,7 +68,7 @@ module mod_ghostcells_update
   ! index ranges to receive restriced ghost cells from finer blocks
   integer, dimension(-1:1, 0:3) :: ixR_r_min1,ixR_r_min2,ixR_r_min3,ixR_r_max1,&
        ixR_r_max2,ixR_r_max3
-  !$acc declare create(ixR_r_min1,ixR_r_min2,ixR_r_min3,ixR_r_max1,ixR_r_max2,ixR_r_max3)
+  ${GPU_DECLARE_CREATE('ixR_r_min1,ixR_r_min2,ixR_r_min3,ixR_r_max1,ixR_r_max2,ixR_r_max3')}$
 
   ! index ranges of staggered variables to receive restriced ghost cells from finer blocks
   integer, dimension(3,0:3)  :: ixR_r_stg_min1,ixR_r_stg_min2,ixR_r_stg_min3,&
@@ -77,8 +78,8 @@ module mod_ghostcells_update
   integer, dimension(-1:1, 0:3) :: ixS_p_min1,ixS_p_min2,ixS_p_min3,ixS_p_max1,&
        ixS_p_max2,ixS_p_max3, ixR_p_min1,ixR_p_min2,ixR_p_min3,ixR_p_max1,&
        ixR_p_max2,ixR_p_max3
-  !$acc declare create(ixS_p_min1,ixS_p_min2,ixS_p_min3,ixS_p_max1,ixS_p_max2,ixS_p_max3)
-  !$acc declare create(ixR_p_min1,ixR_p_min2,ixR_p_min3,ixR_p_max1,ixR_p_max2,ixR_p_max3)
+  ${GPU_DECLARE_CREATE('ixS_p_min1,ixS_p_min2,ixS_p_min3,ixS_p_max1,ixS_p_max2,ixS_p_max3')}$
+  ${GPU_DECLARE_CREATE('ixR_p_min1,ixR_p_min2,ixR_p_min3,ixR_p_max1,ixR_p_max2,ixR_p_max3')}$
 
   ! send prolongated (p) staggered ghost cells to finer blocks, receive prolongated from coarser blocks
   integer, dimension(3,0:3)  :: ixS_p_stg_min1,ixS_p_stg_min2,ixS_p_stg_min3,&
@@ -156,7 +157,7 @@ module mod_ghostcells_update
 contains
 
   subroutine idecode(i1, i2, i3, i)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     integer, intent(in)                       :: i
     integer, intent(out)                      :: i1, i2, i3
     ! .. local ..
@@ -1089,17 +1090,17 @@ contains
 
     end if
 
-    !$acc update device(ixS_srl_min1,ixS_srl_min2,ixS_srl_min3)
-    !$acc update device(ixS_srl_max1,ixS_srl_max2,ixS_srl_max3, ixR_srl_min1,ixR_srl_min2)
-    !$acc update device(ixR_srl_min3,ixR_srl_max1,ixR_srl_max2,ixR_srl_max3)
-    !$acc update device(ixCoGmin1,ixCoGmin2,ixCoGmin3,ixCoGmax1,ixCoGmax2,ixCoGmax3)
-    !$acc update device(ixCoMmin1,ixCoMmin2,ixCoMmin3,ixCoMmax1,ixCoMmax2,ixCoMmax3)
-    !$acc update device(ixCoGsmin1,ixCoGsmin2,ixCoGsmin3,ixCoGsmax1,ixCoGsmax2,ixCoGsmax3)
-    !$acc update device(ixMmin1,ixMmin2,ixMmin3,ixMmax1,ixMmax2,ixMmax3)
-    !$acc update device(ixS_r_min1,ixS_r_min2,ixS_r_min3,ixS_r_max1,ixS_r_max2,ixS_r_max3)
-    !$acc update device(ixR_r_min1,ixR_r_min2,ixR_r_min3,ixR_r_max1,ixR_r_max2,ixR_r_max3)
-    !$acc update device(ixS_p_min1,ixS_p_min2,ixS_p_min3,ixS_p_max1,ixS_p_max2,ixS_p_max3)
-    !$acc update device(ixR_p_min1,ixR_p_min2,ixR_p_min3,ixR_p_max1,ixR_p_max2,ixR_p_max3)
+    ${GPU_UPDATE_DEVICE('ixS_srl_min1,ixS_srl_min2,ixS_srl_min3')}$
+    ${GPU_UPDATE_DEVICE('ixS_srl_max1,ixS_srl_max2,ixS_srl_max3, ixR_srl_min1,ixR_srl_min2')}$
+    ${GPU_UPDATE_DEVICE('ixR_srl_min3,ixR_srl_max1,ixR_srl_max2,ixR_srl_max3')}$
+    ${GPU_UPDATE_DEVICE('ixCoGmin1,ixCoGmin2,ixCoGmin3,ixCoGmax1,ixCoGmax2,ixCoGmax3')}$
+    ${GPU_UPDATE_DEVICE('ixCoMmin1,ixCoMmin2,ixCoMmin3,ixCoMmax1,ixCoMmax2,ixCoMmax3')}$
+    ${GPU_UPDATE_DEVICE('ixCoGsmin1,ixCoGsmin2,ixCoGsmin3,ixCoGsmax1,ixCoGsmax2,ixCoGsmax3')}$
+    ${GPU_UPDATE_DEVICE('ixMmin1,ixMmin2,ixMmin3,ixMmax1,ixMmax2,ixMmax3')}$
+    ${GPU_UPDATE_DEVICE('ixS_r_min1,ixS_r_min2,ixS_r_min3,ixS_r_max1,ixS_r_max2,ixS_r_max3')}$
+    ${GPU_UPDATE_DEVICE('ixR_r_min1,ixR_r_min2,ixR_r_min3,ixR_r_max1,ixR_r_max2,ixR_r_max3')}$
+    ${GPU_UPDATE_DEVICE('ixS_p_min1,ixS_p_min2,ixS_p_min3,ixS_p_max1,ixS_p_max2,ixS_p_max3')}$
+    ${GPU_UPDATE_DEVICE('ixR_p_min1,ixR_p_min2,ixR_p_min3,ixR_p_max1,ixR_p_max2,ixR_p_max3')}$
 
   end subroutine init_bc
 
@@ -1154,7 +1155,7 @@ contains
 
     req_diagonal = .true.
     if (present(req_diag)) req_diagonal = req_diag
-    !$acc update device(req_diagonal)
+    ${GPU_UPDATE_DEVICE('req_diagonal')}$
 
     ! fill internal physical boundary
     if (internalboundary) then
@@ -1163,7 +1164,7 @@ contains
 
     ! fill physical-boundary ghost cells before internal ghost-cell values exchange
     if(bcphys.and. .not.stagger_grid) then
-       !$acc parallel loop gang default(present)
+       ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
        do iigrid = 1, igridstail; igrid=igrids(iigrid);
           if (.not.phyboundblock(igrid)) cycle
           call fill_boundary_before_gc(psb(igrid),igrid,time,qdt)
@@ -1172,12 +1173,12 @@ contains
 
 
     ! prepare coarse values to send to coarser neighbors
-    !$acc parallel loop gang default(present)
+    ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid = 1, igridstail; igrid=igrids(iigrid);
        if (any(neighbor_type(:,:,:,igrid)==neighbor_coarse)) then
 
           CoFiratio=one/dble(2**ndim)
-          !$acc loop collapse(4) vector
+          ${GPU_LOOP_VECTOR("collapse(4)")}$
           do iw = nwhead, nwtail
              do ixCo3 = ixCoMmin3,ixCoMmax3
                 do ixCo2 = ixCoMmin2,ixCoMmax2
@@ -1218,9 +1219,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_srl
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%srl_nb(inb)%rcv%buffer, nbprocs_info%srl_nb(inb)%info_rcv%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%srl_nb(inb)%rcv%buffer, nbprocs_info%srl_nb(inb)%info_rcv%buffer')}$
 #endif
 #endif
        call mpi_irecv_wrapper(nbprocs_info%srl_nb(inb)%rcv%buffer, &
@@ -1231,7 +1232,7 @@ contains
             MPI_INTEGER, nbprocs_info%nbprocs_srl_list(inb), 2, icomm, recv_srl_nb(nbprocs_info%nbprocs_srl + inb), ierrmpi)
 
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
@@ -1239,9 +1240,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_f
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%fine_nb(inb)%rcv%buffer, nbprocs_info%fine_nb(inb)%info_rcv%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%fine_nb(inb)%rcv%buffer, nbprocs_info%fine_nb(inb)%info_rcv%buffer')}$
 #endif
 #endif
        call mpi_irecv_wrapper(nbprocs_info%fine_nb(inb)%rcv%buffer, &
@@ -1251,13 +1252,13 @@ contains
             nbprocs_info%fine_nb(inb)%info_rcv%size, &
             MPI_INTEGER, nbprocs_info%nbprocs_f_list(inb), 2, icomm, recv_f_nb(nbprocs_info%nbprocs_f + inb), ierrmpi)
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
     ! fill the SRL send buffers on GPU
     do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc parallel loop default(present) gang private(igrid, ienc, ibuf_start, i1, i2, i3, ixSmin1, ixSmin2, ixSmin3, Nx1)
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, ixSmin1, ixSmin2, ixSmin3, Nx1)")}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%srl_nb(inb)%info%nigrids
              igrid = nbprocs_info%srl_nb(inb)%info%igrid(i)
              ienc = nbprocs_info%srl_nb(inb)%info%iencode(i)
@@ -1271,7 +1272,7 @@ contains
              ixSmin3=ixS_srl_min3(iib3,i3); ixSmax3=ixS_srl_max3(iib3,i3)
              Nx1=ixSmax1-ixSmin1+1; Nx2=ixSmax2-ixSmin2+1; Nx3=ixSmax3-ixSmin3+1
 
-             !$acc loop collapse(4) vector independent
+             ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
              do iw = nwhead, nwtail
                 do ix3 = ixSmin3, ixSmax3
                    do ix2 = ixSmin2, ixSmax2
@@ -1294,7 +1295,7 @@ contains
 
     ! fill the C send buffers on GPU (send_restrict)
     do inb = 1, nbprocs_info%nbprocs_c
-       !$acc parallel loop gang default(present) private(Nx1,Nx2,Nx3,i1,i2,i3,inc1,inc2,inc3)
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,i1,i2,i3,inc1,inc2,inc3)")}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%course_nb(inb)%info%nigrids
 
           igrid = nbprocs_info%course_nb(inb)%info%igrid(i)
@@ -1320,7 +1321,7 @@ contains
           ixSmax2=ixS_r_max2(iib2,i2);ixSmax3=ixS_r_max3(iib3,i3)
           Nx1=ixSmax1-ixSmin1+1; Nx2=ixSmax2-ixSmin2+1; Nx3=ixSmax3-ixSmin3+1
 
-          !$acc loop collapse(4) vector independent
+          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixSmin3, ixSmax3
                 do ix2 = ixSmin2, ixSmax2
@@ -1344,12 +1345,12 @@ contains
 
 #ifdef NOGPUDIRECT
     do inb = 1, nbprocs_info%nbprocs_srl
-       !$acc update host(nbprocs_info%srl_nb(inb)%info_send%buffer)
-       !$acc update host(nbprocs_info%srl_nb(inb)%send%buffer)
+       ${GPU_UPDATE_HOST('nbprocs_info%srl_nb(inb)%info_send%buffer')}$
+       ${GPU_UPDATE_HOST('nbprocs_info%srl_nb(inb)%send%buffer')}$
     end do
     do inb = 1, nbprocs_info%nbprocs_c
-       !$acc update host(nbprocs_info%course_nb(inb)%info_send%buffer)
-       !$acc update host(nbprocs_info%course_nb(inb)%send%buffer)
+       ${GPU_UPDATE_HOST('nbprocs_info%course_nb(inb)%info_send%buffer')}$
+       ${GPU_UPDATE_HOST('nbprocs_info%course_nb(inb)%send%buffer')}$
     end do
 #endif
 
@@ -1357,9 +1358,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_srl
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%srl_nb(inb)%send%buffer, nbprocs_info%srl_nb(inb)%info_send%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%srl_nb(inb)%send%buffer, nbprocs_info%srl_nb(inb)%info_send%buffer')}$
 #endif
 #endif
        call mpi_isend_wrapper(nbprocs_info%srl_nb(inb)%send%buffer, &
@@ -1369,7 +1370,7 @@ contains
             nbprocs_info%srl_nb(inb)%info_send%size, &
             MPI_INTEGER, nbprocs_info%nbprocs_srl_list(inb), 2, icomm, send_srl_nb(nbprocs_info%nbprocs_srl + inb), ierrmpi)
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
@@ -1377,9 +1378,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_c
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%course_nb(inb)%send%buffer, nbprocs_info%course_nb(inb)%info_send%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%course_nb(inb)%send%buffer, nbprocs_info%course_nb(inb)%info_send%buffer')}$
 #endif
 #endif
        call mpi_isend_wrapper(nbprocs_info%course_nb(inb)%send%buffer, &
@@ -1389,13 +1390,13 @@ contains
             nbprocs_info%course_nb(inb)%info_send%size, &
             MPI_INTEGER, nbprocs_info%nbprocs_c_list(inb), 2, icomm, send_c_nb(nbprocs_info%nbprocs_c + inb), ierrmpi)
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
     ! fill ghost-cell values of sibling blocks and if neighbor is coarser (f2c)
     ! same process case
-    !$acc parallel loop gang collapse(2) default(present)
+    ${GPU_PARALLEL_LOOP_GANG("collapse(2)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid = 1, igridstail
        do i = 1, 27
           call idecode( i1, i2, i3, i)
@@ -1418,7 +1419,7 @@ contains
                    ixRmin3=ixR_srl_min3(iib3,n_i3); ixRmax1=ixR_srl_max1(iib1,n_i1)
                    ixRmax2=ixR_srl_max2(iib2,n_i2); ixRmax3=ixR_srl_max3(iib3,n_i3)
 
-                   !$acc loop collapse(ndim+1) independent vector
+                   ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$ ${GPU_INDEPENDENT()}$
                    do iw = nwhead, nwtail
                       do ix3=1,ixSmax3-ixSmin3+1
                          do ix2=1,ixSmax2-ixSmin2+1
@@ -1448,7 +1449,7 @@ contains
                    ixRmin3=ixR_r_min3(iib3,n_inc3);ixRmax1=ixR_r_max1(iib1,n_inc1)
                    ixRmax2=ixR_r_max2(iib2,n_inc2);ixRmax3=ixR_r_max3(iib3,n_inc3);
 
-                   !$acc loop collapse(ndim+1) independent vector
+                   ${GPU_LOOP_VECTOR("collapse(ndim+1)")}$ ${GPU_INDEPENDENT()}$
                    do iw = nwhead, nwtail
                       do ix3=1,ixSmax3-ixSmin3+1
                          do ix2=1,ixSmax2-ixSmin2+1
@@ -1473,14 +1474,14 @@ contains
     call MPI_WAITALL(nbprocs_info%nbprocs_srl*2, send_srl_nb, sendstatus_srl_nb, ierrmpi)
 #ifdef NOGPUDIRECT
     do inb = 1, nbprocs_info%nbprocs_srl
-      !$acc update device(nbprocs_info%srl_nb(inb)%info_rcv%buffer)
-      !$acc update device(nbprocs_info%srl_nb(inb)%rcv%buffer)
+      ${GPU_UPDATE_DEVICE('nbprocs_info%srl_nb(inb)%info_rcv%buffer')}$
+      ${GPU_UPDATE_DEVICE('nbprocs_info%srl_nb(inb)%rcv%buffer')}$
     end do
 #endif
 
     ! unpack the MPI buffers
     do inb = 1, nbprocs_info%nbprocs_srl
-      !$acc parallel loop gang default(present) independent private(igrid, ienc, ibuf_start, i1, i2, i3, iib1, ixRmin1, ixRmin2, ixRmin3, Nx1)
+      ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, iib1, ixRmin1, ixRmin2, ixRmin3, Nx1)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%srl_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%srl_nb(inb)%info_rcv%buffer( 3 * (i - 1) + 1 )
@@ -1497,7 +1498,7 @@ contains
           ixRmax2=ixR_srl_max2(iib2,i2); ixRmax3=ixR_srl_max3(iib3,i3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
 
-          !$acc loop collapse(4) vector independent private(tempval)
+          ${GPU_LOOP_VECTOR("collapse(4) private(tempval)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
                 do ix2 = ixRmin2, ixRmax2
@@ -1525,14 +1526,14 @@ contains
 
 #ifdef NOGPUDIRECT
     do inb = 1, nbprocs_info%nbprocs_f
-       !$acc update device(nbprocs_info%fine_nb(inb)%info_rcv%buffer(1:nbprocs_info%fine_nb(inb)%info_rcv%size))
-       !$acc update device(nbprocs_info%fine_nb(inb)%rcv%buffer(1:nbprocs_info%fine_nb(inb)%rcv%size))
+       ${GPU_UPDATE_DEVICE('nbprocs_info%fine_nb(inb)%info_rcv%buffer(1:nbprocs_info%fine_nb(inb)%info_rcv%size)')}$
+       ${GPU_UPDATE_DEVICE('nbprocs_info%fine_nb(inb)%rcv%buffer(1:nbprocs_info%fine_nb(inb)%rcv%size)')}$
     end do
 #endif
 
     ! unpack the MPI buffers, fine neighbor, (f_recv), recv_restrict
     do inb = 1, nbprocs_info%nbprocs_f
-       !$acc parallel loop gang default(present)
+       ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1,nbprocs_info%fine_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%fine_nb(inb)%info_rcv%buffer( 5 * (i - 1) + 1 )
@@ -1548,7 +1549,7 @@ contains
           ixRmax2=ixR_r_max2(iib2,inc2); ixRmax3=ixR_r_max3(iib3,inc3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
 
-          !$acc loop collapse(4) vector independent
+          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
                 do ix2 = ixRmin2, ixRmax2
@@ -1575,9 +1576,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_c
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%course_nb(inb)%rcv%buffer, nbprocs_info%course_nb(inb)%info_rcv%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%course_nb(inb)%rcv%buffer, nbprocs_info%course_nb(inb)%info_rcv%buffer')}$
 #endif
 #endif
        call mpi_irecv_wrapper(nbprocs_info%course_nb(inb)%rcv%buffer, &
@@ -1587,13 +1588,13 @@ contains
             nbprocs_info%course_nb(inb)%info_rcv%size, &
             MPI_INTEGER, nbprocs_info%nbprocs_c_list(inb), 2, icomm, recv_c_nb(nbprocs_info%nbprocs_c + inb), ierrmpi)
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
     ! fill the F (neighbor is finer) send buffer on GPU (send_prolong)
     do inb = 1, nbprocs_info%nbprocs_f
-       !$acc parallel loop gang independent private(Nx1,Nx2,Nx3,inc1,inc2,inc3,n_inc1,n_inc2,n_inc3) default(present)
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3,n_inc1,n_inc2,n_inc3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1,nbprocs_info%fine_nb(inb)%info%nigrids
 
           igrid = nbprocs_info%fine_nb(inb)%info%igrid(i)
@@ -1610,7 +1611,7 @@ contains
           ixSmax2=ixS_p_max2(iib2,inc2);ixSmax3=ixS_p_max3(iib3,inc3)
           Nx1=ixSmax1-ixSmin1+1; Nx2=ixSmax2-ixSmin2+1; Nx3=ixSmax3-ixSmin3+1
 
-          !$acc loop collapse(4) vector independent
+          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixSmin3, ixSmax3
                 do ix2 = ixSmin2, ixSmax2
@@ -1640,8 +1641,8 @@ contains
 
 #ifdef NOGPUDIRECT
     do inb = 1, nbprocs_info%nbprocs_f
-      !$acc update host(nbprocs_info%fine_nb(inb)%info_send%buffer)
-      !$acc update host(nbprocs_info%fine_nb(inb)%send%buffer)
+      ${GPU_UPDATE_HOST('nbprocs_info%fine_nb(inb)%info_send%buffer')}$
+      ${GPU_UPDATE_HOST('nbprocs_info%fine_nb(inb)%send%buffer')}$
     end do
 #endif
 
@@ -1649,9 +1650,9 @@ contains
     do inb = 1, nbprocs_info%nbprocs_f
 #ifndef NOGPUDIRECT
 #ifdef _CRAYFTN
-      !$acc host_data use_device(nbprocs_info)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info')}$
 #else
-      !$acc host_data use_device(nbprocs_info%fine_nb(inb)%send%buffer, nbprocs_info%fine_nb(inb)%info_send%buffer)
+      ${GPU_HOST_DATA_USE_DEVICE('nbprocs_info%fine_nb(inb)%send%buffer, nbprocs_info%fine_nb(inb)%info_send%buffer')}$
 #endif
 #endif
        call mpi_isend_wrapper(nbprocs_info%fine_nb(inb)%send%buffer, &
@@ -1661,13 +1662,13 @@ contains
             nbprocs_info%fine_nb(inb)%info_send%size, &
             MPI_INTEGER, nbprocs_info%nbprocs_f_list(inb), 2, icomm, send_f_nb(nbprocs_info%nbprocs_f + inb), ierrmpi)
 #ifndef NOGPUDIRECT
-      !$acc end host_data
+      ${GPU_END_HOST_DATA()}$
 #endif
     end do
 
 
     ! fill coarse ghost-cell values of finer neighbors in the same processor
-    !$acc parallel loop gang collapse(4) private(iib1,iib2,iib3,igrid) default(present)
+    ${GPU_PARALLEL_LOOP_GANG("collapse(4) private(iib1,iib2,iib3,igrid)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid=1,igridstail
        do i3=-1,1
           do i2=-1,1
@@ -1701,7 +1702,7 @@ contains
                                ixRmax2=ixR_p_max2(iib2,n_inc2)
                                ixRmax3=ixR_p_max3(iib3,n_inc3)
 
-                               !$acc loop collapse(4) vector independent
+                               ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
                                do iw = nwhead, nwtail
                                   do ix3 =0, ixRmax3-ixRmin3
                                      do ix2 = 0, ixRmax2-ixRmin2
@@ -1727,7 +1728,6 @@ contains
        end do
 
     end do
-    !$OMP END PARALLEL DO
 
     call MPI_WAITALL(nbprocs_info%nbprocs_c*2, recv_c_nb, recvstatus_c_nb, ierrmpi)
     call MPI_WAITALL(nbprocs_info%nbprocs_f*2, send_f_nb, sendstatus_f_nb, ierrmpi)
@@ -1735,14 +1735,14 @@ contains
 
 #ifdef NOGPUDIRECT
     do inb = 1, nbprocs_info%nbprocs_c
-      !$acc update device(nbprocs_info%course_nb(inb)%info_rcv%buffer(1:nbprocs_info%course_nb(inb)%info_rcv%size))
-      !$acc update device(nbprocs_info%course_nb(inb)%rcv%buffer(1:nbprocs_info%course_nb(inb)%rcv%size))
+      ${GPU_UPDATE_DEVICE('nbprocs_info%course_nb(inb)%info_rcv%buffer(1:nbprocs_info%course_nb(inb)%info_rcv%size)')}$
+      ${GPU_UPDATE_DEVICE('nbprocs_info%course_nb(inb)%rcv%buffer(1:nbprocs_info%course_nb(inb)%rcv%size)')}$
     end do
 #endif
 
     ! unpack the MPI buffers, coarse neighbor, (c_recv), recv_prolong
     do inb = 1, nbprocs_info%nbprocs_c
-       !$acc parallel loop gang independent private(Nx1,Nx2,Nx3,inc1,inc2,inc3) default(present)
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%course_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%course_nb(inb)%info_rcv%buffer( 5 * (i - 1) + 1 )
@@ -1758,7 +1758,7 @@ contains
           ixRmax2=ixR_p_max2(iib2,inc2); ixRmax3=ixR_p_max3(iib3,inc3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
 
-          !$acc loop collapse(4) vector independent
+          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
                 do ix2 = ixRmin2, ixRmax2
@@ -1782,7 +1782,7 @@ contains
     end do
 
     ! do prolongation on the ghost-cell values based on the received coarse values from coarser neighbors (f2c)
-    !$acc parallel loop gang collapse(4) default(present)
+    ${GPU_PARALLEL_LOOP_GANG("collapse(4)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid=1, igridstail
        !      inline variant of call gc_prolong(igrid)
        do i3 = -1, 1
@@ -1813,7 +1813,7 @@ contains
                    xComin2=rnode(rpxmin2_,igrid)-dble(nghostcells)*dxCo2
                    xComin3=rnode(rpxmin3_,igrid)-dble(nghostcells)*dxCo3;
 
-                   !$acc loop collapse(3) vector independent private(slope)
+                   ${GPU_LOOP_VECTOR("collapse(3) private(slope)")}$ ${GPU_INDEPENDENT()}$
                    do ixFi3 = ixFimin3,ixFimax3
                       do ixFi2 = ixFimin2,ixFimax2
                          do ixFi1 = ixFimin1,ixFimax1
@@ -1892,7 +1892,7 @@ contains
     ! This is a Cray compiler directive to force inlining.
     ! Required for OpenACC at optimization levels where it would not be inlined.
     !dir$ inlinealways skip_direction
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     integer, intent(in) :: dir(3)
 
     if (all(dir == 0)) then
@@ -1906,7 +1906,7 @@ contains
 
 
   subroutine fill_coarse_boundary(time,igrid,i1,i2,i3)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
     integer, intent(in) :: igrid,i1,i2,i3
@@ -1982,7 +1982,7 @@ contains
 
   !> Physical boundary conditions
   subroutine fill_boundary_before_gc(s,igrid,time,qdt)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
 
@@ -2045,7 +2045,7 @@ contains
 
   !> Physical boundary conditions
   subroutine fill_boundary_after_gc(s,igrid,time,qdt)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     use mod_global_parameters
     use mod_boundary_conditions, only: bc_phys
 

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 #ifdef _CRAYFTN
 ! locally switch off gpudirect since it does not work reliably with the nested datastructures on LUMI
 #ifndef NOGPUDIRECT

--- a/src/mod_ghostcells_update.fpp
+++ b/src/mod_ghostcells_update.fpp
@@ -1166,7 +1166,7 @@ contains
 
     ! fill physical-boundary ghost cells before internal ghost-cell values exchange
     if(bcphys.and. .not.stagger_grid) then
-       ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid)")}$ ${GPU_DEFAULT_PRESENT()}$
        do iigrid = 1, igridstail; igrid=igrids(iigrid);
           if (.not.phyboundblock(igrid)) cycle
           call fill_boundary_before_gc(psb(igrid),igrid,time,qdt)
@@ -1175,12 +1175,12 @@ contains
 
 
     ! prepare coarse values to send to coarser neighbors
-    ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
+    ${GPU_PARALLEL_LOOP_GANG("private(igrid, CoFiratio, i1, i2, i3)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid = 1, igridstail; igrid=igrids(iigrid);
        if (any(neighbor_type(:,:,:,igrid)==neighbor_coarse)) then
 
           CoFiratio=one/dble(2**ndim)
-          ${GPU_LOOP_VECTOR("collapse(4)")}$
+          ${GPU_LOOP_VECTOR("collapse(4) private(ixFi1, ixFi2, ixFi3, ix1, ix2, ix3)")}$
           do iw = nwhead, nwtail
              do ixCo3 = ixCoMmin3,ixCoMmax3
                 do ixCo2 = ixCoMmin2,ixCoMmax2
@@ -1260,7 +1260,7 @@ contains
 
     ! fill the SRL send buffers on GPU
     do inb = 1, nbprocs_info%nbprocs_srl
-       ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, ixSmin1, ixSmin2, ixSmin3, Nx1)")}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, iib1, iib2, iib3, ixSmin1, ixSmin2, ixSmin3, ixSmax1, ixSmax2, ixSmax3, Nx1, Nx2, Nx3)")}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%srl_nb(inb)%info%nigrids
              igrid = nbprocs_info%srl_nb(inb)%info%igrid(i)
              ienc = nbprocs_info%srl_nb(inb)%info%iencode(i)
@@ -1297,7 +1297,7 @@ contains
 
     ! fill the C send buffers on GPU (send_restrict)
     do inb = 1, nbprocs_info%nbprocs_c
-       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,i1,i2,i3,inc1,inc2,inc3)")}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,i1,i2,i3,inc1,inc2,inc3,igrid,ibuf_start,iib1,iib2,iib3,ixSmin1,ixSmin2,ixSmin3,ixSmax1,ixSmax2,ixSmax3)")}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%course_nb(inb)%info%nigrids
 
           igrid = nbprocs_info%course_nb(inb)%info%igrid(i)
@@ -1398,7 +1398,7 @@ contains
 
     ! fill ghost-cell values of sibling blocks and if neighbor is coarser (f2c)
     ! same process case
-    ${GPU_PARALLEL_LOOP_GANG("collapse(2)")}$ ${GPU_DEFAULT_PRESENT()}$
+    ${GPU_PARALLEL_LOOP_GANG("collapse(2) private(i1,i2,i3, igrid, iib1,iib2,iib3, ipe_neighbor, ineighbor, n_i1,n_i2,n_i3, ixSmin1,ixSmin2,ixSmin3,ixSmax1,ixSmax2,ixSmax3, ixRmin1,ixRmin2,ixRmin3,ixRmax1,ixRmax2,ixRmax3, ic1,ic2,ic3, n_inc1,n_inc2,n_inc3)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid = 1, igridstail
        do i = 1, 27
           call idecode( i1, i2, i3, i)
@@ -1483,7 +1483,7 @@ contains
 
     ! unpack the MPI buffers
     do inb = 1, nbprocs_info%nbprocs_srl
-      ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, iib1, ixRmin1, ixRmin2, ixRmin3, Nx1)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
+      ${GPU_PARALLEL_LOOP_GANG("private(igrid, ienc, ibuf_start, i1, i2, i3, iib1, iib2, iib3, ixRmin1, ixRmin2, ixRmin3, ixRmax1, ixRmax2, ixRmax3, Nx1, Nx2, Nx3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%srl_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%srl_nb(inb)%info_rcv%buffer( 3 * (i - 1) + 1 )
@@ -1535,7 +1535,7 @@ contains
 
     ! unpack the MPI buffers, fine neighbor, (f_recv), recv_restrict
     do inb = 1, nbprocs_info%nbprocs_f
-       ${GPU_PARALLEL_LOOP_GANG()}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(igrid, inc1, inc2, inc3, ibuf_start, iib1, iib2, iib3, ixRmin1, ixRmin2, ixRmin3, ixRmax1, ixRmax2, ixRmax3, Nx1, Nx2, Nx3)")}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1,nbprocs_info%fine_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%fine_nb(inb)%info_rcv%buffer( 5 * (i - 1) + 1 )
@@ -1551,7 +1551,7 @@ contains
           ixRmax2=ixR_r_max2(iib2,inc2); ixRmax3=ixR_r_max3(iib3,inc3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
 
-          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
+          ${GPU_LOOP_VECTOR("collapse(4) private(tempval)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
                 do ix2 = ixRmin2, ixRmax2
@@ -1596,7 +1596,7 @@ contains
 
     ! fill the F (neighbor is finer) send buffer on GPU (send_prolong)
     do inb = 1, nbprocs_info%nbprocs_f
-       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3,n_inc1,n_inc2,n_inc3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3,n_inc1,n_inc2,n_inc3,igrid,ibuf_start,iib1,iib2,iib3,ixSmin1,ixSmin2,ixSmin3,ixSmax1,ixSmax2,ixSmax3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1,nbprocs_info%fine_nb(inb)%info%nigrids
 
           igrid = nbprocs_info%fine_nb(inb)%info%igrid(i)
@@ -1670,7 +1670,7 @@ contains
 
 
     ! fill coarse ghost-cell values of finer neighbors in the same processor
-    ${GPU_PARALLEL_LOOP_GANG("collapse(4) private(iib1,iib2,iib3,igrid)")}$ ${GPU_DEFAULT_PRESENT()}$
+    ${GPU_PARALLEL_LOOP_GANG("collapse(4) private(iib1,iib2,iib3,igrid, ic1,ic2,ic3, inc1,inc2,inc3, ipe_neighbor, ixSmin1,ixSmin2,ixSmin3,ixSmax1,ixSmax2,ixSmax3, ineighbor, n_i1,n_i2,n_i3, n_inc1,n_inc2,n_inc3, ixRmin1,ixRmin2,ixRmin3,ixRmax1,ixRmax2,ixRmax3)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid=1,igridstail
        do i3=-1,1
           do i2=-1,1
@@ -1744,7 +1744,7 @@ contains
 
     ! unpack the MPI buffers, coarse neighbor, (c_recv), recv_prolong
     do inb = 1, nbprocs_info%nbprocs_c
-       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
+       ${GPU_PARALLEL_LOOP_GANG("private(Nx1,Nx2,Nx3,inc1,inc2,inc3,igrid,ibuf_start,iib1,iib2,iib3,ixRmin1,ixRmin2,ixRmin3,ixRmax1,ixRmax2,ixRmax3)")}$ ${GPU_INDEPENDENT()}$ ${GPU_DEFAULT_PRESENT()}$
        do i = 1, nbprocs_info%course_nb(inb)%info%nigrids
 
           igrid       = nbprocs_info%course_nb(inb)%info_rcv%buffer( 5 * (i - 1) + 1 )
@@ -1760,7 +1760,7 @@ contains
           ixRmax2=ixR_p_max2(iib2,inc2); ixRmax3=ixR_p_max3(iib3,inc3)
           Nx1=ixRmax1-ixRmin1+1; Nx2=ixRmax2-ixRmin2+1; Nx3=ixRmax3-ixRmin3+1
 
-          ${GPU_LOOP_VECTOR("collapse(4)")}$ ${GPU_INDEPENDENT()}$
+          ${GPU_LOOP_VECTOR("collapse(4) private(tempval)")}$ ${GPU_INDEPENDENT()}$
           do iw = nwhead, nwtail
              do ix3 = ixRmin3, ixRmax3
                 do ix2 = ixRmin2, ixRmax2
@@ -1784,7 +1784,7 @@ contains
     end do
 
     ! do prolongation on the ghost-cell values based on the received coarse values from coarser neighbors (f2c)
-    ${GPU_PARALLEL_LOOP_GANG("collapse(4)")}$ ${GPU_DEFAULT_PRESENT()}$
+    ${GPU_PARALLEL_LOOP_GANG("collapse(4) private(igrid, iib1,iib2,iib3, ixFimin1,ixFimin2,ixFimin3,ixFimax1,ixFimax2,ixFimax3, dxFi1,dxFi2,dxFi3, dxCo1,dxCo2,dxCo3, invdxCo1,invdxCo2,invdxCo3, xFimin1,xFimin2,xFimin3, xComin1,xComin2,xComin3)")}$ ${GPU_DEFAULT_PRESENT()}$
     do iigrid=1, igridstail
        !      inline variant of call gc_prolong(igrid)
        do i3 = -1, 1
@@ -1815,7 +1815,7 @@ contains
                    xComin2=rnode(rpxmin2_,igrid)-dble(nghostcells)*dxCo2
                    xComin3=rnode(rpxmin3_,igrid)-dble(nghostcells)*dxCo3;
 
-                   ${GPU_LOOP_VECTOR("collapse(3) private(slope)")}$ ${GPU_INDEPENDENT()}$
+                   ${GPU_LOOP_VECTOR("collapse(3) private(slope, xFi1,xFi2,xFi3, ixCo1,ixCo2,ixCo3, xCo1,xCo2,xCo3, eta1,eta2,eta3, iw, idims, hxCo1,hxCo2,hxCo3, jxCo1,jxCo2,jxCo3, slopeL,slopeR,slopeC,signR,signC)")}$ ${GPU_INDEPENDENT()}$
                    do ixFi3 = ixFimin3,ixFimax3
                       do ixFi2 = ixFimin2,ixFimax2
                          do ixFi1 = ixFimin1,ixFimax1

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> This module contains definitions of global parameters and variables and some
 !> generic functions/subroutines used in AMRVAC.
 !>

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> This module contains definitions of global parameters and variables and some
 !> generic functions/subroutines used in AMRVAC.
 !>
@@ -17,11 +18,11 @@ module mod_global_parameters
 
   !> The number of MPI tasks
   integer :: npe
-  !$acc declare create(npe)
+  ${GPU_DECLARE_CREATE('npe')}$
 
   !> The rank of the current MPI task
   integer :: mype
-  !$acc declare create(mype)
+  ${GPU_DECLARE_CREATE('mype')}$
 
   !> The MPI communicator
   integer :: icomm
@@ -51,26 +52,26 @@ module mod_global_parameters
 
   !> the mesh range of a physical block without ghost cells
   integer :: ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3
-  !$acc declare create(ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3)
+  ${GPU_DECLARE_CREATE('ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3')}$
 
   !> minimum and maximum domain boundaries for each dimension
   double precision  :: xprobmin1,xprobmin2,xprobmin3,xprobmax1,xprobmax2,&
      xprobmax3
- !$acc declare create(xprobmin1,xprobmin2,xprobmin3,xprobmax1,xprobmax2,xprobmax3)
+ ${GPU_DECLARE_CREATE('xprobmin1,xprobmin2,xprobmin3,xprobmax1,xprobmax2,xprobmax3')}$
 
   !> Indices for cylindrical coordinates FOR TESTS, negative value when not used:
   integer :: r_ = -1
   integer :: phi_ = -1
   integer :: z_ = -1
-  !$acc declare copyin(r_, phi_, z_)
+  ${GPU_DECLARE_COPYIN('r_, phi_, z_')}$
 
   !> Number of spatial dimensions for grid variables
   integer, parameter :: ndim=3
-  !$acc declare copyin(ndim)
+  ${GPU_DECLARE_COPYIN('ndim')}$
 
   !> Number of spatial dimensions (components) for vector variables
   integer :: ndir=ndim
-  !$acc declare copyin(ndir)
+  ${GPU_DECLARE_COPYIN('ndir')}$
 
   !> starting dimension for electric field
   
@@ -78,19 +79,19 @@ module mod_global_parameters
   
   integer, parameter :: sdim=1
  
-  !$acc declare copyin(sdim)
+  ${GPU_DECLARE_COPYIN('sdim')}$
 
   !> Cartesian geometry or not
   logical :: slab = .true.
-  !$acc declare copyin(slab)
+  ${GPU_DECLARE_COPYIN('slab')}$
 
   !> uniform Cartesian geometry or not (stretched Cartesian)
   logical :: slab_uniform=.true.
-  !$acc declare copyin(slab_uniform)
+  ${GPU_DECLARE_COPYIN('slab_uniform')}$
   
   !> each cell has its own timestep or not
   logical :: local_timestep = .false.
-  !$acc declare copyin(local_timestep)
+  ${GPU_DECLARE_COPYIN('local_timestep')}$
 
   !> number of grid blocks in domain per dimension, in array over levels
   integer, dimension(:), allocatable :: ng1,ng2,ng3
@@ -102,25 +103,25 @@ module mod_global_parameters
 
   !> number of cells for each dimension in grid block excluding ghostcells
   integer :: block_nx1,block_nx2,block_nx3
-  !$acc declare create(block_nx1,block_nx2,block_nx3)
+  ${GPU_DECLARE_CREATE('block_nx1,block_nx2,block_nx3')}$
 
   !> Lower index of grid block arrays (always 1)
   integer, parameter :: ixGlo1 = 1, ixGlo2 = 1, ixGlo3 = 1
 
   !> Upper index of grid block arrays
   integer :: ixGhi1,ixGhi2,ixGhi3
-  !$acc declare create(ixGhi1,ixGhi2,ixGhi3)
+  ${GPU_DECLARE_CREATE('ixGhi1,ixGhi2,ixGhi3')}$
 
   !> Lower index of stagger grid block arrays (always 0)
   integer, parameter :: ixGslo1 = 0, ixGslo2 = 0, ixGslo3 = 0
 
   !> Upper index of stagger grid block arrays
   integer :: ixGshi1,ixGshi2,ixGshi3
-  !$acc declare create(ixGshi1,ixGshi2,ixGshi3)
+  ${GPU_DECLARE_CREATE('ixGshi1,ixGshi2,ixGshi3')}$
 
   !> Number of ghost cells surrounding a grid
   integer :: nghostcells = 2
-  !$acc declare copyin(nghostcells)
+  ${GPU_DECLARE_COPYIN('nghostcells')}$
 
   integer, parameter :: stretch_none = 0 !< No stretching
   integer, parameter :: stretch_uni  = 1 !< Unidirectional stretching from a side
@@ -153,7 +154,7 @@ module mod_global_parameters
 
   integer, allocatable :: node(:,:)
   integer, allocatable :: node_sub(:,:)
-  !$acc declare create(node)
+  ${GPU_DECLARE_CREATE('node')}$
 
   !> grid location info (corner coordinates and grid spacing)
   integer, parameter :: rnodehi=3*3
@@ -167,12 +168,12 @@ module mod_global_parameters
 
   !> Corner coordinates
   double precision, allocatable :: rnode(:,:)
-  !$acc declare create(rnode)
+  ${GPU_DECLARE_CREATE('rnode')}$
   double precision, allocatable :: rnode_sub(:,:)
 
   double precision, allocatable :: dx(:,:)
   double precision :: dxlevel(ndim)
-  !$acc declare create(dxlevel)
+  ${GPU_DECLARE_CREATE('dxlevel')}$
 
   ! IO related quantities
 
@@ -331,7 +332,7 @@ module mod_global_parameters
 
   !> Save a snapshot before crash a run met unphysical values
   logical :: crash=.false.
-  !$acc declare copyin(crash)
+  ${GPU_DECLARE_COPYIN('crash')}$
   
   !> type of physics to build
   character(len=std_len) :: phys
@@ -340,84 +341,84 @@ module mod_global_parameters
 
   !> Physical scaling factor for length
   double precision :: unit_length=1.d0
-  !$acc declare copyin(unit_length)
+  ${GPU_DECLARE_COPYIN('unit_length')}$
 
   !> Physical scaling factor for time
   double precision :: unit_time=1.d0
-  !$acc declare copyin(unit_time)
+  ${GPU_DECLARE_COPYIN('unit_time')}$
 
   !> Physical scaling factor for density
   double precision :: unit_density=1.d0
-  !$acc declare copyin(unit_density)
+  ${GPU_DECLARE_COPYIN('unit_density')}$
 
   !> Physical scaling factor for velocity
   double precision :: unit_velocity=1.d0
-  !$acc declare copyin(unit_velocity)
+  ${GPU_DECLARE_COPYIN('unit_velocity')}$
 
   !> Physical scaling factor for temperature
   double precision :: unit_temperature=1.d0
-  !$acc declare copyin(unit_temperature)
+  ${GPU_DECLARE_COPYIN('unit_temperature')}$
 
   !> Physical scaling factor for pressure
   double precision :: unit_pressure=1.d0
-  !$acc declare copyin(unit_pressure)
+  ${GPU_DECLARE_COPYIN('unit_pressure')}$
 
   !> Physical scaling factor for magnetic field
   double precision :: unit_magneticfield=1.d0
-  !$acc declare copyin(unit_magneticfield)
+  ${GPU_DECLARE_COPYIN('unit_magneticfield')}$
 
   !> Physical scaling factor for number density
   double precision :: unit_numberdensity=1.d0
-  !$acc declare copyin(unit_numberdensity)
+  ${GPU_DECLARE_COPYIN('unit_numberdensity')}$
 
   !> Physical scaling factor for charge
   double precision :: unit_charge=1.d0
-  !$acc declare copyin(unit_charge)
+  ${GPU_DECLARE_COPYIN('unit_charge')}$
 
   !> Physical scaling factor for mass
   double precision :: unit_mass=1.d0
-  !$acc declare copyin(unit_mass)  
+  ${GPU_DECLARE_COPYIN('unit_mass')}$
 
   !> Normalised speed of light
   double precision :: c_norm=1.d0
-  !$acc declare copyin(c_norm)
+  ${GPU_DECLARE_COPYIN('c_norm')}$
 
   !> Physical scaling factor for Opacity
   double precision :: unit_opacity=1.d0
-  !$acc declare copyin(unit_opacity)
+  ${GPU_DECLARE_COPYIN('unit_opacity')}$
 
   !> Physical scaling factor for radiation flux
   double precision :: unit_radflux=1.d0
-  !$acc declare copyin(unit_radflux)
+  ${GPU_DECLARE_COPYIN('unit_radflux')}$
 
   !> error handling
   double precision :: small_temperature,small_pressure,small_density
-  !$acc declare create(small_temperature,small_pressure,small_density)
+  ${GPU_DECLARE_CREATE('small_temperature,small_pressure,small_density')}$
 
   !> amplitude of background dipolar, quadrupolar, octupolar, user's field
   double precision :: Bdip=0.d0
   double precision :: Bquad=0.d0
   double precision :: Boct=0.d0
   double precision :: Busr=0.d0
-  !$acc declare copyin(Bdip, Bquad, Boct, Busr)
+  ${GPU_DECLARE_COPYIN('Bdip, Bquad, Boct, Busr')}$
 
   !> check and optionally fix unphysical small values (density, gas pressure)
   logical :: check_small_values=.true.
   logical :: fix_small_values=.false.
-  !$acc declare copyin(check_small_values, fix_small_values)
+  ${GPU_DECLARE_COPYIN('check_small_values, fix_small_values')}$
 
   !> split magnetic field as background B0 field
   ! TODO these should be moved in a different file  
   logical :: B0field=.false.
   logical :: B0fieldAllocCoarse=.false.
-  !$acc declare copyin(B0field, B0fieldAllocCoarse)
+  ${GPU_DECLARE_COPYIN('B0field, B0fieldAllocCoarse')}$
 
   ! number of equilibrium set variables, besides the mag field
   integer :: number_equi_vars = 0
 
   !> Use SI units (.true.) or use cgs units (.false.)
   logical :: SI_unit=.false.
-  !$acc declare copyin(SI_unit)
+  ${GPU_DECLARE_COPYIN('SI_unit')}$
 
   !> Use TRAC (Johnston 2019 ApJL, 873, L22) for MHD or 1D HD
   logical :: phys_trac=.false.
@@ -434,21 +435,21 @@ module mod_global_parameters
 
   !> The maximum number of grid blocks in a processor
   integer :: max_blocks=4000
-  !$acc declare copyin(max_blocks)
+  ${GPU_DECLARE_COPYIN('max_blocks')}$
 
   !> The maximum number of levels in the grid refinement
   integer, parameter :: nlevelshi = 20
 
   !> Maximal number of AMR levels
   integer :: refine_max_level
-  !$acc declare create(refine_max_level)
+  ${GPU_DECLARE_CREATE('refine_max_level')}$
 
   !> Specify to use user-defined refinement criterion
   logical :: refine_usr = .false.
   
   !> Weights of variables used to calculate error for mesh refinement
   double precision, allocatable :: w_refine_weight(:)
-  !$acc declare create(w_refine_weight)
+  ${GPU_DECLARE_CREATE('w_refine_weight')}$
 
   !> Fix the AMR grid after this time
   double precision :: tfixgrid
@@ -464,23 +465,23 @@ module mod_global_parameters
 
   !> refinement: lohner estimate wavefilter setting
   double precision, allocatable :: amr_wavefilter(:)
-  !$acc declare create(amr_wavefilter)
+  ${GPU_DECLARE_CREATE('amr_wavefilter')}$
 
   integer                       :: refine_criterion
   logical                       :: prolongprimitive=.false.
   logical                       :: coarsenprimitive=.false.
-  !$acc declare copyin(prolongprimitive, coarsenprimitive)
+  ${GPU_DECLARE_COPYIN('prolongprimitive, coarsenprimitive')}$
 
   !> Error tolerance for refinement decision
   double precision, allocatable :: refine_threshold(:)
   double precision, allocatable :: derefine_ratio(:)
-  !$acc declare create(refine_threshold, derefine_ratio)
+  ${GPU_DECLARE_CREATE('refine_threshold, derefine_ratio')}$
 
   !> If true, rebuild the AMR grid upon restarting
   logical :: reset_grid
   !> True for using stagger grid
   logical :: stagger_grid=.false.
-  !$acc declare copyin(stagger_grid)
+  ${GPU_DECLARE_COPYIN('stagger_grid')}$
   
   !> True for record electric field
   logical :: record_electric_field=.false.
@@ -506,14 +507,14 @@ module mod_global_parameters
   ! Time integration aspects
 
   double precision :: dt
-  !$acc declare create(kr,lvc,dt)
+  ${GPU_DECLARE_CREATE('kr,lvc,dt')}$
 
   logical :: time_advance
-  !$acc declare create(time_advance)
+  ${GPU_DECLARE_CREATE('time_advance')}$
 
   !> The Courant (CFL) number used for the simulation
   double precision :: courantpar
-  !$acc declare create(courantpar)
+  ${GPU_DECLARE_CREATE('courantpar')}$
 
   !> How to compute the CFL-limited time step
   integer :: type_courant=1
@@ -529,11 +530,11 @@ module mod_global_parameters
   !> For resistive MHD, the time step is also limited by the diffusion time:
   !> \f$ dt < dtdiffpar \times dx^2/eta \f$
   double precision :: dtdiffpar
-  !$acc declare create(dtdiffpar)
+  ${GPU_DECLARE_CREATE('dtdiffpar')}$
 
   !> The global simulation time
   double precision :: global_time
-  !$acc declare create(global_time)
+  ${GPU_DECLARE_CREATE('global_time')}$
 
   !> Start time for the simulation
   double precision :: time_init
@@ -568,11 +569,11 @@ module mod_global_parameters
 
   !> If true, do H-correction to fix the carbuncle problem at grid-aligned shocks
   logical :: H_correction=.false.
-  !$acc declare copyin(H_correction)
+  ${GPU_DECLARE_COPYIN('H_correction')}$
 
   !> Number of time steps taken
   integer :: it
-  !$acc declare create(it)
+  ${GPU_DECLARE_CREATE('it')}$
 
   !> Stop the simulation after this many time steps have been taken
   integer :: it_max
@@ -602,11 +603,11 @@ module mod_global_parameters
 
   !> Adaptive LLF diffusion (Rempel et al. 2009): phi in [flux_ad_min, 1] per face per variable
   logical  :: flux_adaptive_diffusion = .false.
-  !$acc declare create(flux_adaptive_diffusion)
+  ${GPU_DECLARE_CREATE('flux_adaptive_diffusion')}$
   double precision :: flux_ad_min             = 0.0d0
-  !$acc declare create(flux_ad_min)
+  ${GPU_DECLARE_CREATE('flux_ad_min')}$
   double precision :: flux_ad_scale           = 1.0d0
-  !$acc declare create(flux_ad_scale)
+  ${GPU_DECLARE_CREATE('flux_ad_scale')}$
 
   !> time stepper type
   integer :: t_stepper=0
@@ -641,16 +642,16 @@ module mod_global_parameters
 
   !> Type of slope limiter used for reconstructing variables on cell edges
   integer, allocatable :: type_limiter(:)
-  !$acc declare create(type_limiter)
+  ${GPU_DECLARE_CREATE('type_limiter')}$
 
   !> Type of slope limiter used for computing gradients or divergences, when
   !> typegrad or typediv are set to 'limited'
   integer, allocatable :: type_gradient_limiter(:)
-  !$acc declare create(type_gradient_limiter)
+  ${GPU_DECLARE_CREATE('type_gradient_limiter')}$
 
   !> background magnetic field location indicator
   integer :: b0i=0
-  !$acc declare copyin(b0i)
+  ${GPU_DECLARE_COPYIN('b0i')}$
 
   !> Limiter used for prolongation to refined grids and ghost cells
   integer :: prolong_limiter=0
@@ -658,20 +659,20 @@ module mod_global_parameters
   character(len=std_len) :: typedimsplit
   character(len=std_len) :: geometry_name='default'
   character(len=std_len) :: typepoly
-  !$acc declare copyin(typedimsplit, geometry_name, typepoly)
+  ${GPU_DECLARE_COPYIN('typedimsplit, geometry_name, typepoly')}$
 
   logical, allocatable          :: loglimit(:), logflag(:)
-  !$acc declare create(loglimit, logflag)
+  ${GPU_DECLARE_CREATE('loglimit, logflag')}$
   logical                       :: flatcd,flatsh
-  !$acc declare create(flatcd, flatsh)
+  ${GPU_DECLARE_CREATE('flatcd, flatsh')}$
   !> Use split or unsplit way to add user's source terms, default: unsplit
   logical                       :: source_split_usr
-  !$acc declare create(source_split_usr)
+  ${GPU_DECLARE_CREATE('source_split_usr')}$
   !> if any normal source term is added in split fasion
   logical                       :: any_source_split=.false.
-  !$acc declare copyin(any_source_split)
+  ${GPU_DECLARE_COPYIN('any_source_split')}$
   logical                       :: dimsplit
-  !$acc declare create(dimsplit)
+  ${GPU_DECLARE_CREATE('dimsplit')}$
 
   !> RK2(alfa) method parameters from Butcher tableau
   double precision              :: rk_a21,rk_b1,rk_b2
@@ -686,9 +687,9 @@ module mod_global_parameters
      rk_alfa41,rk_alfa44
   double precision              :: rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,&
      rk_alfa55,rk_c5
- !$acc declare create(rk_beta11,rk_beta22,rk_beta33,rk_beta44,rk_c2,rk_c3,rk_c4)
- !$acc declare create(rk_alfa21,rk_alfa22,rk_alfa31,rk_alfa33,rk_alfa41,rk_alfa44)
- !$acc declare create(rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,rk_alfa55,rk_c5)
+ ${GPU_DECLARE_CREATE('rk_beta11,rk_beta22,rk_beta33,rk_beta44,rk_c2,rk_c3,rk_c4')}$
+ ${GPU_DECLARE_CREATE('rk_alfa21,rk_alfa22,rk_alfa31,rk_alfa33,rk_alfa41,rk_alfa44')}$
+ ${GPU_DECLARE_CREATE('rk_beta54,rk_beta55,rk_alfa53,rk_alfa54,rk_alfa55,rk_c5')}$
   !> RK3 Butcher table
   integer                       :: rk3_switch
   double precision              :: rk3_a21,rk3_a31,rk3_a32,rk3_b1,rk3_b2,&
@@ -704,52 +705,52 @@ module mod_global_parameters
   double precision              :: imex_a22, imex_a33, imex_ha32
   !> whether IMEX in use or not
   logical                       :: use_imex_scheme
-  !$acc declare create(use_imex_scheme)
+  ${GPU_DECLARE_CREATE('use_imex_scheme')}$
 
   character(len=std_len) :: typediv,typegrad
 
   !> global fastest wave speed needed in fd scheme and glm method
   double precision :: cmax_global
-  !$acc declare create(cmax_global)
+  ${GPU_DECLARE_CREATE('cmax_global')}$
 
   !> global largest a2 for schmid scheme
   double precision :: a2max_global(ndim)
-  !$acc declare create(a2max_global)
+  ${GPU_DECLARE_CREATE('a2max_global')}$
 
   !> need global maximal wave speed
   logical :: need_global_cmax=.false.
-  !$acc declare create(need_global_cmax)
+  ${GPU_DECLARE_CREATE('need_global_cmax')}$
 
   !> global value for schmid scheme
   logical :: need_global_a2max=.false.
-  !$acc declare create(need_global_a2max)
+  ${GPU_DECLARE_CREATE('need_global_a2max')}$
 
   ! Boundary region parameters
 
   !> True for dimensions with periodic boundaries
   logical :: periodB(ndim)
-  !$acc declare create(periodB)
+  ${GPU_DECLARE_CREATE('periodB')}$
 
   !> Indicates whether there is a pole at a boundary
   logical :: poleB(2,ndim)
-  !$acc declare create(poleB)
+  ${GPU_DECLARE_CREATE('poleB')}$
 
   !> True for dimensions with aperiodic boundaries
   logical :: aperiodB(ndim)
-  !$acc declare create(aperiodB)
+  ${GPU_DECLARE_CREATE('aperiodB')}$
 
   !> True for save physical boundary cells in dat files
   logical :: save_physical_boundary
-  !$acc declare create(save_physical_boundary)
+  ${GPU_DECLARE_CREATE('save_physical_boundary')}$
 
   !> True if a block has any physical boundary
   logical, allocatable :: phyboundblock(:)
-  !$acc declare create(phyboundblock)
+  ${GPU_DECLARE_CREATE('phyboundblock')}$
 
   !> Array indicating the type of boundary condition per variable and per
   !> physical boundary
   integer, allocatable :: typeboundary(:, :)
-  !$acc declare create(typeboundary)
+  ${GPU_DECLARE_CREATE('typeboundary')}$
   !> boundary condition types
   integer, parameter :: bc_special=1
   integer, parameter :: bc_cont=2
@@ -763,15 +764,15 @@ module mod_global_parameters
   integer, parameter :: bc_icarus=10
   !> signal to the precompiler that we need special boundaries:
   logical            :: specialboundary = .false.
-  !$acc declare copyin(specialboundary)
+  ${GPU_DECLARE_COPYIN('specialboundary')}$
 
   !> whether copy values instead of interpolation in ghost cells of finer blocks
   logical :: ghost_copy=.false.
-  !$acc declare create(ghost_copy)
+  ${GPU_DECLARE_CREATE('ghost_copy')}$
 
   !> if there is an internal boundary
   logical :: internalboundary
-  !$acc declare create(internalboundary)
+  ${GPU_DECLARE_CREATE('internalboundary')}$
 
   !> Base file name for synthetic EUV emission output
   character(len=std_len) :: filename_euv
@@ -816,10 +817,7 @@ module mod_global_parameters
 
   !> Block pointer for using one block and its previous state
   type(state), pointer :: block
-  !$acc declare create(block)
-
-  !$OMP THREADPRIVATE(block,dxlevel,b0i)
-
+  ${GPU_DECLARE_CREATE('block')}$
 contains
 
   !> Cross product of two vectors

--- a/src/mod_global_parameters.fpp
+++ b/src/mod_global_parameters.fpp
@@ -67,19 +67,13 @@ module mod_global_parameters
 
   !> Number of spatial dimensions for grid variables
   integer, parameter :: ndim=3
-  ${GPU_DECLARE_COPYIN('ndim')}$
 
   !> Number of spatial dimensions (components) for vector variables
   integer :: ndir=ndim
   ${GPU_DECLARE_COPYIN('ndir')}$
 
-  !> starting dimension for electric field
-  
-  
-  
+  !> starting dimension for electric field 
   integer, parameter :: sdim=1
- 
-  ${GPU_DECLARE_COPYIN('sdim')}$
 
   !> Cartesian geometry or not
   logical :: slab = .true.

--- a/src/mod_gpu_directives.fpp
+++ b/src/mod_gpu_directives.fpp
@@ -1,0 +1,251 @@
+#:mute
+!=====================================================================
+! GPU offload directive macros.
+!
+! Every `!$acc`/`!$omp` directive in the codebase is written by calling
+! one of the macros below, so that a single source line expands to the
+! correct directive for whichever GPU backend is selected at build time
+! (`make OPENACC=1` or `make OPENMP=1`.
+!=====================================================================
+
+#:if defined('OPENACC')
+
+#:def GPU_DECLARE_CREATE(vars)
+!$acc declare create(${vars}$)
+#:enddef
+
+#:def GPU_DECLARE_COPYIN(vars)
+!$acc declare copyin(${vars}$)
+#:enddef
+
+#:def GPU_ROUTINE_SEQ()
+!$acc routine seq
+#:enddef
+
+#:def GPU_ROUTINE_VECTOR()
+!$acc routine vector
+#:enddef
+
+#:def GPU_ROUTINE()
+!$acc routine
+#:enddef
+
+#:def GPU_PARALLEL_LOOP(clauses='')
+!$acc parallel loop ${clauses}$
+#:enddef
+
+#:def GPU_PARALLEL_LOOP_GANG(clauses='')
+!$acc parallel loop gang ${clauses}$
+#:enddef
+
+#:def GPU_LOOP_VECTOR(clauses='')
+!$acc loop vector ${clauses}$
+#:enddef
+
+#:def GPU_LOOP_SEQ()
+!$acc loop seq
+#:enddef
+
+#:def GPU_PRESENT(vars)
+present(${vars}$)
+#:enddef
+
+#:def GPU_DEFAULT_PRESENT()
+default(present)
+#:enddef
+
+#:def GPU_INDEPENDENT()
+independent
+#:enddef
+
+#:def GPU_ENTER_DATA_COPYIN(vars)
+!$acc enter data copyin(${vars}$)
+#:enddef
+
+#:def GPU_ENTER_DATA_CREATE(vars)
+!$acc enter data create(${vars}$)
+#:enddef
+
+#:def GPU_EXIT_DATA_DELETE(vars)
+!$acc exit data delete(${vars}$)
+#:enddef
+
+#:def GPU_UPDATE_DEVICE(vars)
+!$acc update device(${vars}$)
+#:enddef
+
+#:def GPU_UPDATE_HOST(vars)
+!$acc update host(${vars}$)
+#:enddef
+
+#:def GPU_HOST_DATA_USE_DEVICE(vars)
+!$acc host_data use_device(${vars}$)
+#:enddef
+
+#:def GPU_END_HOST_DATA()
+!$acc end host_data
+#:enddef
+
+#:elif defined('OPENMP')
+
+#:def GPU_DECLARE_CREATE(vars)
+!$omp declare target(${vars}$)
+#:enddef
+
+#:def GPU_DECLARE_COPYIN(vars)
+!$omp declare target(${vars}$)
+#:enddef
+
+#:def GPU_ROUTINE_SEQ()
+!$omp declare target
+#:enddef
+
+#:def GPU_ROUTINE_VECTOR()
+!$omp declare target
+#:enddef
+
+#:def GPU_ROUTINE()
+!$omp declare target
+#:enddef
+
+#:def GPU_PARALLEL_LOOP(clauses='')
+!$omp target teams distribute parallel do ${clauses}$
+#:enddef
+
+#:def GPU_PARALLEL_LOOP_GANG(clauses='')
+!$omp target teams distribute ${clauses}$
+#:enddef
+
+#:def GPU_LOOP_VECTOR(clauses='')
+!$omp parallel do ${clauses}$
+#:enddef
+
+#:def GPU_LOOP_SEQ()
+#:enddef
+
+#:def GPU_PRESENT(vars)
+#:enddef
+
+#:def GPU_DEFAULT_PRESENT()
+#:enddef
+
+#:def GPU_INDEPENDENT()
+#:enddef
+
+#:def GPU_ENTER_DATA_COPYIN(vars)
+!$omp target enter data map(to: ${vars}$)
+#:enddef
+
+#:def GPU_ENTER_DATA_CREATE(vars)
+!$omp target enter data map(alloc: ${vars}$)
+#:enddef
+
+#:def GPU_EXIT_DATA_DELETE(vars)
+!$omp target exit data map(delete: ${vars}$)
+#:enddef
+
+#:def GPU_UPDATE_DEVICE(vars)
+#! Ensure each referenced variable has device storage before refreshing its
+#! value. Entering the *base* variable (not the specific, possibly
+#! subscripted, expression) is essential: repeatedly calling `enter data`
+#! with a different array-element expression each time (e.g. rnode(1,igrid)
+#! for varying igrid) confuses nvfortran's OpenMP runtime and silently drops
+#! the data motion for every element after the first. Entering the same base
+#! variable repeatedly is a harmless no-op once it is present, and the
+#! `update to` below (which always transfers, regardless of presence) then
+#! correctly refreshes the specific element.
+#:set depth = 0
+#:set parts = ['']
+#:for ch in vars
+#:if ch == '('
+#:set depth = depth + 1
+#:endif
+#:if ch == ')'
+#:set depth = depth - 1
+#:endif
+#:if ch == ',' and depth == 0
+#:set parts = parts + ['']
+#:else
+#:set parts = parts[:-1] + [parts[-1] + ch]
+#:endif
+#:endfor
+#:set parts = [p.strip() for p in parts]
+#:set bases = list(dict.fromkeys([p.split('(')[0].strip() for p in parts]))
+!$omp target enter data map(to: ${', '.join(bases)}$)
+!$omp target update to(${vars}$)
+#:enddef
+
+#:def GPU_UPDATE_HOST(vars)
+!$omp target update from(${vars}$)
+#:enddef
+
+#:def GPU_HOST_DATA_USE_DEVICE(vars)
+!$omp target data use_device_addr(${vars}$)
+#:enddef
+
+#:def GPU_END_HOST_DATA()
+!$omp end target data
+#:enddef
+
+#:else
+#! CPU build
+
+#:def GPU_DECLARE_CREATE(vars)
+#:enddef
+
+#:def GPU_DECLARE_COPYIN(vars)
+#:enddef
+
+#:def GPU_ROUTINE_SEQ()
+#:enddef
+
+#:def GPU_ROUTINE_VECTOR()
+#:enddef
+
+#:def GPU_ROUTINE()
+#:enddef
+
+#:def GPU_PARALLEL_LOOP(clauses='')
+#:enddef
+
+#:def GPU_PARALLEL_LOOP_GANG(clauses='')
+#:enddef
+
+#:def GPU_LOOP_VECTOR(clauses='')
+#:enddef
+
+#:def GPU_LOOP_SEQ()
+#:enddef
+
+#:def GPU_PRESENT(vars)
+#:enddef
+
+#:def GPU_DEFAULT_PRESENT()
+#:enddef
+
+#:def GPU_INDEPENDENT()
+#:enddef
+
+#:def GPU_ENTER_DATA_COPYIN(vars)
+#:enddef
+
+#:def GPU_ENTER_DATA_CREATE(vars)
+#:enddef
+
+#:def GPU_EXIT_DATA_DELETE(vars)
+#:enddef
+
+#:def GPU_UPDATE_DEVICE(vars)
+#:enddef
+
+#:def GPU_UPDATE_HOST(vars)
+#:enddef
+
+#:def GPU_HOST_DATA_USE_DEVICE(vars)
+#:enddef
+
+#:def GPU_END_HOST_DATA()
+#:enddef
+
+#:endif
+#:endmute

--- a/src/mod_gpu_directives.fpp
+++ b/src/mod_gpu_directives.fpp
@@ -1,4 +1,3 @@
-#:mute
 !=====================================================================
 ! GPU offload directive macros.
 !
@@ -309,4 +308,3 @@ use, intrinsic :: iso_c_binding, only: c_loc
 #:enddef
 
 #:endif
-#:endmute

--- a/src/mod_gpu_directives.fpp
+++ b/src/mod_gpu_directives.fpp
@@ -70,6 +70,32 @@ independent
 !$acc exit data delete(${vars}$)
 #:enddef
 
+#:def GPU_EXIT_DATA_DELETE_IF_PRESENT(vars)
+#:set depth = 0
+#:set parts = ['']
+#:for ch in vars
+#:if ch == '('
+#:set depth = depth + 1
+#:endif
+#:if ch == ')'
+#:set depth = depth - 1
+#:endif
+#:if ch == ',' and depth == 0
+#:set parts = parts + ['']
+#:else
+#:set parts = parts[:-1] + [parts[-1] + ch]
+#:endif
+#:endfor
+#:set parts = [p.strip() for p in parts]
+#:for part in parts
+!$acc exit data delete(${part}$) if(acc_is_present(${part}$))
+#:endfor
+#:enddef
+
+#:def GPU_USE_IS_PRESENT()
+use openacc, only : acc_is_present
+#:enddef
+
 #:def GPU_UPDATE_DEVICE(vars)
 !$acc update device(${vars}$)
 #:enddef
@@ -142,6 +168,35 @@ independent
 
 #:def GPU_EXIT_DATA_DELETE(vars)
 !$omp target exit data map(delete: ${vars}$)
+#:enddef
+
+#:def GPU_EXIT_DATA_DELETE_IF_PRESENT(vars)
+#:set depth = 0
+#:set parts = ['']
+#:for ch in vars
+#:if ch == '('
+#:set depth = depth + 1
+#:endif
+#:if ch == ')'
+#:set depth = depth - 1
+#:endif
+#:if ch == ',' and depth == 0
+#:set parts = parts + ['']
+#:else
+#:set parts = parts[:-1] + [parts[-1] + ch]
+#:endif
+#:endfor
+#:set parts = [p.strip() for p in parts]
+#:for part in parts
+if (omp_target_is_present(c_loc(${part}$), omp_get_default_device()) /= 0) then
+    !$omp target exit data map(delete: ${part}$)
+end if
+#:endfor
+#:enddef
+
+#:def GPU_USE_IS_PRESENT()
+use omp_lib, only: omp_target_is_present, omp_get_default_device
+use, intrinsic :: iso_c_binding, only: c_loc
 #:enddef
 
 #:def GPU_UPDATE_DEVICE(vars)
@@ -233,6 +288,12 @@ independent
 #:enddef
 
 #:def GPU_EXIT_DATA_DELETE(vars)
+#:enddef
+
+#:def GPU_EXIT_DATA_DELETE_IF_PRESENT(vars)
+#:enddef
+
+#:def GPU_USE_IS_PRESENT()
 #:enddef
 
 #:def GPU_UPDATE_DEVICE(vars)

--- a/src/mod_gpu_utils.fpp
+++ b/src/mod_gpu_utils.fpp
@@ -1,9 +1,13 @@
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(_OPENMP)
 !=====================================================================
 ! Transfer wrappers for copy or update if present
 !=====================================================================
-module acc_utils
+module gpu_utils
+#:if defined('OPENACC')
   use openacc
+#:elif defined('OPENMP')
+  use omp_lib
+#:endif
   implicit none
 
   private
@@ -12,7 +16,7 @@ module acc_utils
   ! Adjust this as needed
   #:set MAXRANK = 6
   #:set TYPES = [("double", "double precision"), ("logical", "logical"), ("integer", "integer")]
-                 
+
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Generic interface for arrays and scalars (non-pointer, non-allocatable)
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -22,14 +26,14 @@ module acc_utils
      module procedure copy_or_update_${tname}$_nonpointer_r${rank}$
   #:endfor
   #:endfor
-     
+
   #:for tname, tdecl in TYPES
     module procedure copy_or_update_${tname}$_nonpointer
   #:endfor
   end interface copy_or_update
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  
+
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Generic interface for data with pointer attribute
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -39,14 +43,14 @@ module acc_utils
      module procedure copy_or_update_${tname}$_pointer_r${rank}$
   #:endfor
   #:endfor
-     
+
   #:for tname, tdecl in TYPES
     module procedure copy_or_update_${tname}$_pointer
   #:endfor
   end interface copy_or_update_pointer
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
- 
+
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Generic interface for arrays with allocatable attribute
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -69,18 +73,19 @@ contains
     logical, optional, intent(in)     :: no_update
 
     logical                           :: no_update_
-    
+
     if (present(no_update)) then
        no_update_ = no_update
     else
        no_update_ = .false.
     end if
-    
+
     if (.not. associated(scalar)) then
        print *, 'copy_or_update: null-pointer encountered'
        return
     end if
 
+#:if defined('OPENACC')
     if (.not. acc_is_present(scalar, sizeof(scalar))) then
        !$acc enter data copyin(scalar)
        !$acc enter data attach(scalar)
@@ -89,7 +94,20 @@ contains
     end if
     call acc_detach(scalar)
     call acc_attach(scalar)
-    
+#:elif defined('OPENMP')
+    ! No presence check (unlike the OpenACC branch above): OpenMP has no
+    ! Fortran-friendly equivalent of acc_is_present for arbitrary
+    ! pointer/array/scalar arguments, and pointer attachment happens
+    ! implicitly when both the pointer and its target are mapped. This is
+    ! always correct for the transferred *value*, at the cost of an
+    ! ever-growing device refcount on repeated calls (map(to:) on an
+    ! already-present item only bumps the refcount, it does not recopy).
+    !$omp target enter data map(to: scalar)
+    if (.not. no_update_) then
+       !$omp target update to(scalar)
+    end if
+#:endif
+
   end subroutine copy_or_update_${tname}$_pointer
 
   ! Versions for scalars, non-pointers
@@ -99,30 +117,37 @@ contains
     logical, optional, intent(in)     :: no_update
 
     logical                           :: no_update_
-    
+
     if (present(no_update)) then
        no_update_ = no_update
     else
        no_update_ = .false.
-    end if    
+    end if
 
+#:if defined('OPENACC')
     if (.not. acc_is_present(scalar, sizeof(scalar))) then
        !$acc enter data copyin(scalar)
     else if (.not. no_update_) then
        !$acc update device(scalar)
     end if
-    
+#:elif defined('OPENMP')
+    !$omp target enter data map(to: scalar)
+    if (.not. no_update_) then
+       !$omp target update to(scalar)
+    end if
+#:endif
+
   end subroutine copy_or_update_${tname}$_nonpointer
 
   #:endfor
 
   ! Versions for various array ranks
-  
+
   #:for tname, tdecl in TYPES
   ! Generate non-pointer and pointer versions for ranks 1..MAXRANK
   #:for rank in range(1, MAXRANK+1)
   #:set shp = '(' + ','.join([':']*rank) + ')'
-  
+
   !------------------------------
   ! Non-pointer, non-allocatable
   !------------------------------
@@ -132,19 +157,26 @@ contains
     logical, optional, intent(in)     :: no_update
 
     logical                           :: no_update_
-    
+
     if (present(no_update)) then
        no_update_ = no_update
     else
        no_update_ = .false.
     end if
 
+#:if defined('OPENACC')
     if (.not. acc_is_present(array)) then
        !$acc enter data copyin(array)
     else if (.not. no_update_) then
        !$acc update device(array)
     end if
-    
+#:elif defined('OPENMP')
+    !$omp target enter data map(to: array)
+    if (.not. no_update_) then
+       !$omp target update to(array)
+    end if
+#:endif
+
   end subroutine copy_or_update_${tname}$_nonpointer_r${rank}$
 
   !-------------
@@ -156,7 +188,7 @@ contains
     logical, optional, intent(in)     :: no_update
 
     logical                           :: no_update_
-    
+
     if (present(no_update)) then
        no_update_ = no_update
     else
@@ -168,6 +200,7 @@ contains
        return
     end if
 
+#:if defined('OPENACC')
     if (.not. acc_is_present(array)) then
        !$acc enter data copyin(array)
        !$acc enter data attach(array)
@@ -176,7 +209,16 @@ contains
     end if
     call acc_detach(array)
     call acc_attach(array)
-    
+#:elif defined('OPENMP')
+    ! See the comment in copy_or_update_${tname}$_pointer above: no presence
+    ! check, and attach/detach is dropped since OpenMP attaches a mapped
+    ! pointer to its (also mapped) target implicitly.
+    !$omp target enter data map(to: array)
+    if (.not. no_update_) then
+       !$omp target update to(array)
+    end if
+#:endif
+
   end subroutine copy_or_update_${tname}$_pointer_r${rank}$
 
   !----------------
@@ -188,7 +230,7 @@ contains
     logical, optional, intent(in)     :: no_update
 
     logical                           :: no_update_
-    
+
     if (present(no_update)) then
        no_update_ = no_update
     else
@@ -199,17 +241,24 @@ contains
        print *, 'copy_or_update: unallocated allocatable (rank ${rank}$)'
        return
     end if
-    
+
+#:if defined('OPENACC')
     if (.not. acc_is_present(array)) then
        !$acc enter data copyin(array)
     else if (.not. no_update_) then
        !$acc update device(array)
     end if
-    
+#:elif defined('OPENMP')
+    !$omp target enter data map(to: array)
+    if (.not. no_update_) then
+       !$omp target update to(array)
+    end if
+#:endif
+
   end subroutine copy_or_update_${tname}$_alloc_r${rank}$
 
   #:endfor
   #:endfor
 
-end module acc_utils
+end module gpu_utils
 #endif

--- a/src/mod_initialize.fpp
+++ b/src/mod_initialize.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> This module handles the initialization of various components of amrvac
 module mod_initialize
   use mod_comm_lib, only: mpistop
@@ -64,7 +65,7 @@ contains
     allocate(ps4(max_blocks))
     
     allocate(psc(max_blocks))
-    !$acc enter data copyin(ps,ps1,ps2,ps3,ps4,psc)
+    ${GPU_ENTER_DATA_COPYIN('ps,ps1,ps2,ps3,ps4,psc')}$
     
     allocate(ps_sub(max_blocks+1)) ! since we reserve one for communication
     allocate(neighbor(2,-1:1,-1:1,-1:1,max_blocks),neighbor_child(2,0:3,0:3,&
@@ -80,13 +81,13 @@ contains
     allocate(pflux(2,3,max_blocks))
 
     allocate( bg(1:nstep) )
-    !$acc enter data copyin(bg)
+    ${GPU_ENTER_DATA_COPYIN('bg')}$
     do istep = 1 , nstep
        bg(istep)%istep = istep
        allocate( bg(istep)%w(ixGlo1:ixGhi1,ixGlo2:ixGhi2,ixGlo3:ixGhi3, 1:nw,&
             1:max_blocks) )
-       !$acc update device(bg(istep))
-       !$acc enter data copyin( bg(istep)%w )
+       ${GPU_UPDATE_DEVICE('bg(istep)')}$
+       ${GPU_ENTER_DATA_COPYIN('bg(istep)%w')}$
     end do
     allocate( bgc(1) )
     ixCoGmin1=1;ixCoGmin2=1;ixCoGmin3=1;
@@ -96,8 +97,8 @@ contains
 
     allocate ( bgc(1)%w(ixCoGmin1:ixCoGmax1, ixCoGmin2:ixCoGmax2, &
     ixCoGmin3:ixCoGmax3, 1:nw, 1:max_blocks) )
-     !$acc update device( bgc(1) )
-     !$acc enter data copyin( bgc(1)%w ) 
+     ${GPU_UPDATE_DEVICE('bgc(1)')}$
+     ${GPU_ENTER_DATA_COPYIN('bgc(1)%w')}$
 
     do igrid = 1, max_blocks
        ps(igrid)%igrid  = igrid; ps(igrid)%istep  = 1
@@ -130,7 +131,7 @@ contains
     ixMlo1=ixGlo1+nghostcells;ixMlo2=ixGlo2+nghostcells
     ixMlo3=ixGlo3+nghostcells;ixMhi1=ixGhi1-nghostcells
     ixMhi2=ixGhi2-nghostcells;ixMhi3=ixGhi3-nghostcells;
-    !$acc update device(ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3)
+    ${GPU_UPDATE_DEVICE('ixMlo1,ixMlo2,ixMlo3,ixMhi1,ixMhi2,ixMhi3')}$
 
     if (nbufferx1>(ixMhi1-ixMlo1+1).or.nbufferx2>(ixMhi2-ixMlo2+&
        1).or.nbufferx3>(ixMhi3-ixMlo3+1)) then
@@ -248,7 +249,7 @@ contains
     end if
     allocate(igrid_inuse(max_blocks,0:npe-1))
     igrid_inuse=.false.
-    !$acc update device(coarsen, refine, buffer, igrid_inuse)
+    ${GPU_UPDATE_DEVICE('coarsen, refine, buffer, igrid_inuse')}$
 
     allocate(tree_root(1:ng1(1),1:ng2(1),1:ng3(1)))
     do ig3=1,ng3(1)

--- a/src/mod_initialize.fpp
+++ b/src/mod_initialize.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> This module handles the initialization of various components of amrvac
 module mod_initialize
   use mod_comm_lib, only: mpistop

--- a/src/mod_physicaldata.fpp
+++ b/src/mod_physicaldata.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 module mod_physicaldata
   implicit none
 

--- a/src/mod_physicaldata.fpp
+++ b/src/mod_physicaldata.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 module mod_physicaldata
   implicit none
 
@@ -113,11 +114,11 @@ module mod_physicaldata
   type(state), dimension(:), allocatable, target :: ps4
   !> array of physical blocks, one level coarser representative
   type(state), dimension(:), allocatable, target :: psc
-  !$acc declare create(ps, ps1, ps2, ps3, ps4, psc)
+  ${GPU_DECLARE_CREATE('ps, ps1, ps2, ps3, ps4, psc')}$
 
   !> one block grid to rule them all
   type(block_grid_t), dimension(:), allocatable, target   :: bg, bgc
-  !$acc declare create(bg, bgc)
+  ${GPU_DECLARE_CREATE('bg, bgc')}$
 
   !> array of physical blocks in reduced dimension
   type(state_sub), dimension(:), allocatable, target :: ps_sub

--- a/src/mod_small_values.fpp
+++ b/src/mod_small_values.fpp
@@ -30,8 +30,8 @@ contains
 #if defined(_CRAYFTN) && defined(_OPENACC)
   subroutine small_values_error_gpu(wprim, x, ixImin1,ixImin2,ixImin3,ixImax1,&
      ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w_flag)
-    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
     integer, intent(in)          :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
     double precision, intent(in) :: wprim(ixImin1:ixImax1,ixImin2:ixImax2,&
@@ -78,10 +78,10 @@ contains
   subroutine small_values_error(wprim, x, ixImin1,ixImin2,ixImin3,ixImax1,&
      ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w_flag,&
       subname)
+    use mod_global_parameters
 #ifndef _CRAYFTN
     ${GPU_ROUTINE()}$
 #endif
-    use mod_global_parameters
     integer, intent(in)          :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
     double precision, intent(in) :: wprim(ixImin1:ixImax1,ixImin2:ixImax2,&
@@ -128,8 +128,8 @@ contains
   subroutine small_values_average(ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
      ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w, x, w_flag,&
       windex)
-    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
     integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
     logical, intent(in)             :: w_flag(ixImin1:ixImax1,ixImin2:ixImax2,&

--- a/src/mod_small_values.fpp
+++ b/src/mod_small_values.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 !> Module for handling problematic values in simulations, such as negative
 !> pressures
 module mod_small_values
@@ -7,19 +8,19 @@ module mod_small_values
 
   !> How to handle small values
   character(len=20), public :: small_values_method = "error"
-  !$acc declare copyin(small_values_method)
+  ${GPU_DECLARE_COPYIN('small_values_method')}$
 
   !> Average over this many cells in each direction
   integer, public :: small_values_daverage = 1
-  !$acc declare copyin(small_values_daverage)
+  ${GPU_DECLARE_COPYIN('small_values_daverage')}$
 
   !> trace small values in the source file using traceback flag of compiler
   logical, public :: trace_small_values=.false.
-  !$acc declare copyin(trace_small_values)
+  ${GPU_DECLARE_COPYIN('trace_small_values')}$
 
   !> Whether to apply small value fixes to certain variables
   logical, public, allocatable :: small_values_fix_iw(:)
-  !$acc declare create(small_values_fix_iw)
+  ${GPU_DECLARE_CREATE('small_values_fix_iw')}$
 
   public :: small_values_error
   public :: small_values_average
@@ -29,7 +30,7 @@ contains
 #if defined(_CRAYFTN) && defined(_OPENACC)
   subroutine small_values_error_gpu(wprim, x, ixImin1,ixImin2,ixImin3,ixImax1,&
      ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w_flag)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
     integer, intent(in)          :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
@@ -48,7 +49,7 @@ contains
           do ix1= ixOmin1,ixOmax1
           if(w_flag(ix1,ix2,ix3,iw)) then
 !FIXME:
-#ifndef _OPENACC
+#if !defined(_OPENACC) && !defined(_OPENMP)
             write(*,*) "Error: small value of ", trim(prim_wnames(iw)),&
                wprim(ix1,ix2,ix3,iw)," encountered"
             write(*,*) "Iteration: ", it, " Time: ", global_time,&
@@ -78,7 +79,7 @@ contains
      ixImax2,ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w_flag,&
       subname)
 #ifndef _CRAYFTN
-    !$acc routine
+    ${GPU_ROUTINE()}$
 #endif
     use mod_global_parameters
     integer, intent(in)          :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
@@ -99,7 +100,7 @@ contains
           do ix1= ixOmin1,ixOmax1
           if(w_flag(ix1,ix2,ix3,iw)) then
 !FIXME:
-#ifndef _OPENACC
+#if !defined(_OPENACC) && !defined(_OPENMP)
             write(*,*) "Error: small value of ", trim(prim_wnames(iw)),&
                wprim(ix1,ix2,ix3,iw)," encountered when call ", subname
             write(*,*) "Iteration: ", it, " Time: ", global_time,&
@@ -127,7 +128,7 @@ contains
   subroutine small_values_average(ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
      ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, w, x, w_flag,&
       windex)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
     integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
@@ -185,7 +186,7 @@ contains
             end if
          else
 !FIXME:            
-#ifndef _OPENACC
+#if !defined(_OPENACC) && !defined(_OPENMP)
             write(*,*) "no cells without error were found in cube of size",&
                 small_values_daverage
             write(*,*) "at location:", x(ix1,ix2,ix3, 1:ndim)

--- a/src/mod_small_values.fpp
+++ b/src/mod_small_values.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 !> Module for handling problematic values in simulations, such as negative
 !> pressures
 module mod_small_values

--- a/src/mod_source.fpp
+++ b/src/mod_source.fpp
@@ -1,6 +1,7 @@
 !> Module for handling split source terms (split from the fluxes)
 
 #:mute
+#:include "mod_gpu_directives.fpp"
 #:include "physics/mod_physics_templates.fpp"
 #:endmute
 
@@ -17,7 +18,7 @@ module mod_source
   !> @ref discretization.md
   !> defaulting to sfs
   integer :: sourcesplit = 0
-  !$acc declare copyin(sourcesplit)
+  ${GPU_DECLARE_COPYIN('sourcesplit')}$
   integer, parameter :: sourcesplit_sfs    = 0
   integer, parameter :: sourcesplit_sf     = 1
   integer, parameter :: sourcesplit_ssf    = 2
@@ -68,12 +69,12 @@ contains
 
       select case (sourcesplit)
       case (sourcesplit_sfs)
-         !$acc parallel loop gang private(n, dr) default(present)
+         ${GPU_PARALLEL_LOOP_GANG("private(n, dr)")}$ ${GPU_DEFAULT_PRESENT()}$
          do iigrid=1,igridstail_active
             n = igrids_active(iigrid)            
             dr  = rnode(rpdx1_:rnodehi, n)
             
-            !$acc loop collapse(ndim) vector private(xloc, wprim, wnew, wCT)
+            ${GPU_LOOP_VECTOR("collapse(ndim) private(xloc, wprim, wnew, wCT)")}$
             do ix3=ixOmin3,ixOmax3 
                do ix2=ixOmin2,ixOmax2 
                   do ix1=ixOmin1,ixOmax1

--- a/src/mod_variables.fpp
+++ b/src/mod_variables.fpp
@@ -1,3 +1,4 @@
+#:include "mod_gpu_directives.fpp"
 module mod_variables
   use mod_basic_types
 
@@ -6,51 +7,51 @@ module mod_variables
 
   !> Number of flux variables
   integer           :: nwflux = 0
-  !$acc declare copyin(nwflux)
+  ${GPU_DECLARE_COPYIN('nwflux')}$
 
   !> Number of flux variables which need user to specify boundary type
   integer           :: nwfluxbc = 0
-  !$acc declare copyin(nwfluxbc)
+  ${GPU_DECLARE_COPYIN('nwfluxbc')}$
 
   !> Number of auxiliary variables in w
   integer           :: nwaux = 0
-  !$acc declare copyin(nwaux)
+  ${GPU_DECLARE_COPYIN('nwaux')}$
 
   !> Number of extra variables in w
   integer           :: nwextra = 0
-  !$acc declare copyin(nwextra)
+  ${GPU_DECLARE_COPYIN('nwextra')}$
 
   !> Number of extra variables in wextra seperated from w
   integer           :: nw_extra = 0
-  !$acc declare copyin(nw_extra)
+  ${GPU_DECLARE_COPYIN('nw_extra')}$
 
   !> Total number of variables
   integer           :: nw = 0
-  !$acc declare copyin(nw)
+  ${GPU_DECLARE_COPYIN('nw')}$
 
   !> Total number of stagger variables
   integer           :: nws = 0
-  !$acc declare copyin(nws)
+  ${GPU_DECLARE_COPYIN('nws')}$
 
   !> Number of variables which need to be updated in ghost cells
   integer           :: nwgc = 0
-  !$acc declare copyin(nwgc)
+  ${GPU_DECLARE_COPYIN('nwgc')}$
 
   !> Number of vector variables (used for writing output)
   integer           :: nvector = 0
-  !$acc declare copyin(nvector)
+  ${GPU_DECLARE_COPYIN('nvector')}$
 
   !> Indices of vector variables
   integer, dimension(:), allocatable :: iw_vector
-  !$acc declare create(iw_vector)
+  ${GPU_DECLARE_CREATE('iw_vector')}$
 
   ! the number of the first w variable to exchange ghost cells
   integer            :: iwstart=1
-  !$acc declare copyin(iwstart)
+  ${GPU_DECLARE_COPYIN('iwstart')}$
   
   !> Maximum number of variables
   integer, parameter :: max_nw = 50
-  !$acc declare copyin(max_nw)
+  ${GPU_DECLARE_COPYIN('max_nw')}$
 
   !> Primitive variable names
   character(len=name_len) :: prim_wnames(max_nw)
@@ -62,64 +63,64 @@ module mod_variables
 
   !> Index of the (gas) density
   integer :: iw_rho = -1
-  !$acc declare copyin(iw_rho)
+  ${GPU_DECLARE_COPYIN('iw_rho')}$
 
   !> Indices of the momentum density
   integer, allocatable :: iw_mom(:)
-  !$acc declare create(iw_mom)
+  ${GPU_DECLARE_CREATE('iw_mom')}$
 
   !> Index of the energy density
   integer :: iw_e = -1
-  !$acc declare copyin(iw_e)
+  ${GPU_DECLARE_COPYIN('iw_e')}$
 
   !> Index of the (scalar, field-aligned-only) heat flux (isotropic HTC only)
   integer :: iw_q = -1
-  !$acc declare copyin(iw_q)
+  ${GPU_DECLARE_COPYIN('iw_q')}$
 
   !> Indices of the heat flux vector components (anisotropic HTC only)
   integer, allocatable, protected :: iw_qvec(:)
-  !$acc declare create(iw_qvec)
+  ${GPU_DECLARE_CREATE('iw_qvec')}$
 
   !> Index of the radiation energy density
   integer :: iw_r_e = -1
-  !$acc declare copyin(iw_r_e)
+  ${GPU_DECLARE_COPYIN('iw_r_e')}$
 
   !> Indices of the magnetic field components
   integer, allocatable, protected :: iw_mag(:)
-  !$acc declare create(iw_mag)
+  ${GPU_DECLARE_CREATE('iw_mag')}$
 
   !> Index of the cutoff temperature for the TRAC method
   integer :: iw_tcoff = -1
-  !$acc declare copyin(iw_tcoff)
+  ${GPU_DECLARE_COPYIN('iw_tcoff')}$
 
   !> number of species: each species has different characterictic speeds and should
   !> be used accordingly in mod_finite_volume and mod_finite_difference
   integer :: number_species = 1
-  !$acc declare copyin(number_species)
+  ${GPU_DECLARE_COPYIN('number_species')}$
 
   !> index of the var
   !> whose velocity appears in the induction eq.
   integer :: index_v_mag = 1
-  !$acc declare copyin(index_v_mag)
+  ${GPU_DECLARE_COPYIN('index_v_mag')}$
 
   !> the indices in 1:nwflux array are assumed consecutive for each species
   !> this array should be of size number_species and contain the first index in the array of
   !> the number_species
   integer, allocatable :: start_indices(:)
-  !$acc declare create(start_indices)
+  ${GPU_DECLARE_CREATE('start_indices')}$
 
   !> the indices in 1:nwflux array are assumed consecutive for each species
   !> this array should be of size number_species and contain the last index in the array of
   !> the first number_species, the last index for the last one is nwflux
   integer, allocatable :: stop_indices(:)
-  !$acc declare create(stop_indices)
+  ${GPU_DECLARE_CREATE('stop_indices')}$
 
 
   ! indices of equi for the species index_v_mag
   ! these are needed for hlld solver, TODO: consider moving in a separate file
   integer :: iw_equi_rho = -1
   integer :: iw_equi_p = -1
-  !$acc declare copyin(iw_equi_rho, iw_equi_p)
+  ${GPU_DECLARE_COPYIN('iw_equi_rho, iw_equi_p')}$
 
 contains
 
@@ -148,7 +149,7 @@ contains
       write(prim_wnames(nwflux),"(A,I0)") name_prim, ix
    end if
 
-   !$acc update device(nwflux, nw, nwfluxbc)
+   ${GPU_UPDATE_DEVICE('nwflux, nw, nwfluxbc')}$
   end function var_set_fluxvar
 
   !> Set extra variable in w, which is not advected and has no boundary conditions.
@@ -169,7 +170,7 @@ contains
       write(cons_wnames(iw),"(A,I0)") name_cons, ix
       write(prim_wnames(iw),"(A,I0)") name_prim, ix
    end if
-   !$acc update device(nwextra,nw)
+   ${GPU_UPDATE_DEVICE('nwextra,nw')}$
   end function var_set_extravar
 
   !> Set extra variable in wextra, which is not advected and has no boundary conditions and not output in dat.
@@ -179,7 +180,7 @@ contains
 
     nw_extra = nw_extra + 1
     iw      = nw_extra
-   !$acc update device(nw_extra)
+   ${GPU_UPDATE_DEVICE('nw_extra')}$
   end function var_set_wextra
 
   !> Set auxiliary variable, which is not advected but has boundary conditions.
@@ -200,7 +201,7 @@ contains
       write(cons_wnames(iw),"(A,I0)") name_cons, ix
       write(prim_wnames(iw),"(A,I0)") name_prim, ix
    end if
-   !$acc update device(nwaux,nw)
+   ${GPU_UPDATE_DEVICE('nwaux,nw')}$
   end function var_set_auxvar
 
   !> Set density variable
@@ -214,7 +215,7 @@ contains
     iw                  = nwflux
     prim_wnames(nwflux) = 'rho'
     cons_wnames(nwflux) = 'rho'
-    !$acc update device(nwflux,nw,nwfluxbc,iw_rho)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_rho')}$
   end function var_set_rho
 
   ! THE INCLUDE files cannot use other modules
@@ -246,7 +247,7 @@ contains
       write(cons_wnames(nwflux),"(A1,I1)") "m", idir
       write(prim_wnames(nwflux),"(A1,I1)") "v", idir
     end do
-    !$acc update device(nwflux,nw,nwfluxbc,iw_mom)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_mom')}$
   end function var_set_momentum
 
   !> Set energy variable
@@ -260,7 +261,7 @@ contains
     iw                  = nwflux
     cons_wnames(nwflux) = 'e'
     prim_wnames(nwflux) = 'p'
-    !$acc update device(nwflux,nw,nwfluxbc,iw_e)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_e')}$
   end function var_set_energy
 
   !> Set heat flux variable (hyperbolic TC treatment)
@@ -279,7 +280,7 @@ contains
     iw                  = nwflux
     cons_wnames(nwflux) = 'q'
     prim_wnames(nwflux) = 'q'
-    !$acc update device(nwflux,nw,nwfluxbc,iw_q)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_q')}$
   end function var_set_q
 
   !> Set heat-flux vector variables (anisotropic HTC only): the full
@@ -305,7 +306,7 @@ contains
       write(cons_wnames(nwflux),"(A4,I1)") "qvec", idir
       write(prim_wnames(nwflux),"(A4,I1)") "qvec", idir
     end do
-    !$acc update device(nwflux,nw,nwfluxbc,iw_qvec)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_qvec')}$
   end function var_set_qvec
 
   function var_set_radiation_energy() result(iw)
@@ -318,7 +319,7 @@ contains
     iw                  = nwflux
     cons_wnames(nwflux) = 'r_e'
     prim_wnames(nwflux) = 'r_e'
-    !$acc update device(nwflux,nw,nwfluxbc,iw_r_e)
+    ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_r_e')}$
   end function var_set_radiation_energy
 
   !> Set magnetic field variables
@@ -338,7 +339,7 @@ contains
       write(cons_wnames(nwflux),"(A1,I1)") "b", idir
       write(prim_wnames(nwflux),"(A1,I1)") "b", idir
    end do
-   !$acc update device(nwflux,nw,nwfluxbc,iw_mag)
+   ${GPU_UPDATE_DEVICE('nwflux,nw,nwfluxbc,iw_mag')}$
   end function var_set_bfield
 
 end module mod_variables

--- a/src/mod_variables.fpp
+++ b/src/mod_variables.fpp
@@ -51,7 +51,6 @@ module mod_variables
   
   !> Maximum number of variables
   integer, parameter :: max_nw = 50
-  ${GPU_DECLARE_COPYIN('max_nw')}$
 
   !> Primitive variable names
   character(len=name_len) :: prim_wnames(max_nw)

--- a/src/mod_variables.fpp
+++ b/src/mod_variables.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "mod_gpu_directives.fpp"
+#:endmute
 module mod_variables
   use mod_basic_types
 

--- a/src/particle/mod_particle_base.fpp
+++ b/src/particle/mod_particle_base.fpp
@@ -2114,16 +2114,13 @@ contains
     sndrqst_payload = MPI_REQUEST_NULL; rcvrqst_payload = MPI_REQUEST_NULL;
 
     ! check if and where to send each particle, destroy if necessary
-    !    !$OMP PARALLEL DO PRIVATE(ipart)
     do iipart=1,nparticles_on_mype;ipart=particles_on_mype(iipart);
 
        ! first check if the particle should be destroyed (user defined criterion)
        if (associated(usr_destroy_particle)) then
          if (usr_destroy_particle(particle(ipart))) then
-           !          !$OMP CRITICAL(destroy)
            destroy_n_particles_mype  = destroy_n_particles_mype + 1
            particle_index_to_be_destroyed(destroy_n_particles_mype) = ipart
-           !          !$OMP END CRITICAL(destroy)
            cycle
          end if
        end if
@@ -2138,11 +2135,9 @@ contains
              call apply_periodB(particle(ipart)%self,igrid_particle,&
                 ipe_particle,BC_applied)
              if (.not. BC_applied .or. igrid_particle == -1) then
-                !                !$OMP CRITICAL(destroy2)
                 destroy_n_particles_mype  = destroy_n_particles_mype + 1
                 particle_index_to_be_destroyed(destroy_n_particles_mype) = &
                    ipart
-                !                !$OMP END CRITICAL(destroy2)
                 cycle
              end if
           end if
@@ -2153,7 +2148,6 @@ contains
 
           ! if we have more than one core, is it on another cpu?
           if (npe .gt. 1 .and. particle(ipart)%ipe .ne. mype) then
-             !             !$OMP CRITICAL(send)
              send_n_particles_to_ipe(ipe_particle) = &
                 send_n_particles_to_ipe(ipe_particle) + 1
              if (send_n_particles_to_ipe(ipe_particle) .gt. &
@@ -2161,13 +2155,11 @@ contains
                 mpistop('too many particles, increase nparticles_per_cpu_hi')
              particle_index_to_be_sent_to_ipe(send_n_particles_to_ipe(&
                 ipe_particle),ipe_particle) = ipart
-             !             !$OMP END CRITICAL(send)
           end if ! ipe_particle
 
        end if ! particle_in_grid
 
     end do ! ipart
-    !    !$OMP END PARALLEL DO
 
     call destroy_particles(destroy_n_particles_mype,&
        particle_index_to_be_destroyed(1:destroy_n_particles_mype))
@@ -2322,7 +2314,6 @@ contains
     sndrqst = MPI_REQUEST_NULL; rcvrqst = MPI_REQUEST_NULL;
 
     ! check if and where to send each particle, relocate all of them (in case grid has changed)
-    !    !$OMP PARALLEL DO PRIVATE(ipart)
     do iipart=1,nparticles_on_mype;ipart=particles_on_mype(iipart);
 
        call find_particle_ipe(particle(ipart)%self%x,igrid_particle,&
@@ -2333,7 +2324,6 @@ contains
 
        ! if we have more than one core, is it on another cpu?
        if (particle(ipart)%ipe .ne. mype) then
-          !          !$OMP CRITICAL(send)
           send_n_particles_to_ipe(ipe_particle) = &
              send_n_particles_to_ipe(ipe_particle) + 1
           if (send_n_particles_to_ipe(ipe_particle) .gt. &
@@ -2341,11 +2331,9 @@ contains
              mpistop('G: too many particles increase nparticles_per_cpu_hi')
           particle_index_to_be_sent_to_ipe(send_n_particles_to_ipe(&
              ipe_particle),ipe_particle) = ipart
-          !          !$OMP END CRITICAL(send)
        end if ! ipe_particle
 
     end do ! ipart
-    !    !$OMP END PARALLEL DO
 
     ! get out when only one core:
     if (npe == 1) then

--- a/src/physics/mod_physics.fpp
+++ b/src/physics/mod_physics.fpp
@@ -224,12 +224,10 @@ contains
     integer :: iigrid, igrid
 
     ! Just copy in nul state
-    !$OMP PARALLEL DO PRIVATE(igrid)
     do iigrid=1,igridstail; igrid=igrids(iigrid);
        psa(igrid)%w = 0.0d0*psa(igrid)%w
        if(stagger_grid) psa(igrid)%ws = 0.0d0*psa(igrid)%ws
     end do
-    !$OMP END PARALLEL DO
 
   end subroutine dummy_evaluate_implicit
 
@@ -243,12 +241,10 @@ contains
     integer :: iigrid, igrid
 
     ! Just copy in psb state when using the scheme without implicit part
-    !$OMP PARALLEL DO PRIVATE(igrid)
     do iigrid=1,igridstail; igrid=igrids(iigrid);
        psa(igrid)%w = psb(igrid)%w
        if(stagger_grid) psa(igrid)%ws = psb(igrid)%ws
     end do
-    !$OMP END PARALLEL DO
 
   end subroutine dummy_implicit_update
 

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -1,10 +1,11 @@
+#:include "../mod_gpu_directives.fpp"
 ! Dummy routines which can be overwritten by a physics-dependent implementation
 ! On non-Cray compilers, these call mpistop with a descriptive message.
 ! On Cray, STOP cannot be inlined into OpenACC kernels, so dummies just return -1. 
 
 #:def estimate_speeds_minmax()
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #ifndef _CRAYFTN
   use mod_comm_lib, only: mpistop
 #endif
@@ -25,7 +26,7 @@ end subroutine estimate_speeds_minmax
 
 #:def estimate_speeds_toro_pvrs()
 subroutine estimate_speeds_toro_pvrs(uL, uR, xC, flux_dim, sL, sR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #ifndef _CRAYFTN
   use mod_comm_lib, only: mpistop
 #endif
@@ -47,7 +48,7 @@ end subroutine estimate_speeds_toro_pvrs
 #:def addsource_nonlocal()
 subroutine addsource_nonlocal(qdt, dtfactor, qtC, wCTprim, qt, wnew, x, dx, idir, &
      qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCTprim(nw_phys,5)
@@ -63,7 +64,7 @@ end subroutine addsource_nonlocal
 #:def addsource_compact()
 subroutine addsource_compact(qdt, dtfactor, qtC, wCTprim1, wCTprim2, wCTprim3, qt, wnew, x, dx, &
      qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCTprim1(nw_phys,3),wCTprim2(nw_phys,3),wCTprim3(nw_phys,3)

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 ! Dummy routines which can be overwritten by a physics-dependent implementation
 ! On non-Cray compilers, these call mpistop with a descriptive message.
 ! On Cray, STOP cannot be inlined into OpenACC kernels, so dummies just return -1. 

--- a/src/physics/mod_physics_dummies.fpp
+++ b/src/physics/mod_physics_dummies.fpp
@@ -5,10 +5,10 @@
 
 #:def estimate_speeds_minmax()
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
-  ${GPU_ROUTINE_SEQ()}$
 #ifndef _CRAYFTN
   use mod_comm_lib, only: mpistop
 #endif
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim
@@ -26,10 +26,10 @@ end subroutine estimate_speeds_minmax
 
 #:def estimate_speeds_toro_pvrs()
 subroutine estimate_speeds_toro_pvrs(uL, uR, xC, flux_dim, sL, sR)
-  ${GPU_ROUTINE_SEQ()}$
 #ifndef _CRAYFTN
   use mod_comm_lib, only: mpistop
 #endif
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer,  intent(in)  :: flux_dim

--- a/src/physics/mod_physics_vars.fpp
+++ b/src/physics/mod_physics_vars.fpp
@@ -1,4 +1,5 @@
 #:mute
+#:include "../mod_gpu_directives.fpp"
 #:include 'mod_physics_templates.fpp'
 #:endmute
 
@@ -9,21 +10,21 @@ module mod_physics_vars
   public
   
   double precision :: phys_gamma=5.d0/3.d0
-  !$acc declare copyin(phys_gamma)
+  ${GPU_DECLARE_COPYIN('phys_gamma')}$
 
   !> String describing the physics type of the simulation
   character(len=name_len) :: physics_type = "${PHYS}$"
-  !$acc declare copyin(physics_type)
+  ${GPU_DECLARE_COPYIN('physics_type')}$
 
   !> To use wider stencils in flux calculations. A value of 1 will extend it by
   !> one cell in both directions, in any dimension
   integer :: phys_wider_stencil = 0
-  !$acc declare copyin(phys_wider_stencil)
+  ${GPU_DECLARE_COPYIN('phys_wider_stencil')}$
 
   !> Array per direction per variable, which can be used to specify that certain
   !> fluxes have to be treated differently
   integer, allocatable :: flux_type(:, :)
-  !$acc declare create(flux_type)
+  ${GPU_DECLARE_CREATE('flux_type')}$
 
   !> Indicates a normal flux
   integer, parameter   :: flux_default        = 0
@@ -33,27 +34,27 @@ module mod_physics_vars
   !> Whether the physics routines require diagonal ghost cells, for example for
   !> computing a curl.
   logical :: phys_req_diagonal = .true.
-  !$acc declare copyin(phys_req_diagonal)
+  ${GPU_DECLARE_COPYIN('phys_req_diagonal')}$
 
   !> Solve energy equation or not
   logical :: phys_energy=.false.
-  !$acc declare copyin(phys_energy)
+  ${GPU_DECLARE_COPYIN('phys_energy')}$
   
   !> Solve total energy equation or not
   logical :: phys_total_energy=.false.
-  !$acc declare copyin(phys_total_energy)
+  ${GPU_DECLARE_COPYIN('phys_total_energy')}$
 
   !> Solve internal energy instead of total energy
   logical :: phys_internal_e=.false.
-  !$acc declare copyin(phys_internal_e)
+  ${GPU_DECLARE_COPYIN('phys_internal_e')}$
 
   !> Solve partially ionized one-fluid plasma
   logical :: phys_partial_ionization=.false.
-  !$acc declare copyin(phys_partial_ionization)
+  ${GPU_DECLARE_COPYIN('phys_partial_ionization')}$
 
   !> if equilibrium pressure is splitted
   logical :: phys_equi_pe=.false.
-  !$acc declare copyin(phys_equi_pe)
+  ${GPU_DECLARE_COPYIN('phys_equi_pe')}$
 
   @:phys_vars()
 

--- a/src/physics/mod_radiative_cooling.fpp
+++ b/src/physics/mod_radiative_cooling.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_radiative_cooling
 
 #:if defined('COOLING')

--- a/src/physics/mod_radiative_cooling.fpp
+++ b/src/physics/mod_radiative_cooling.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_radiative_cooling
 
 #:if defined('COOLING')
@@ -34,7 +35,7 @@ module mod_radiative_cooling
   !> inverse of the adiabatic index minus 1
   double precision, private :: invgam
 
-  !$acc declare create(rc_gamma_1, invgam)
+  ${GPU_DECLARE_CREATE('rc_gamma_1, invgam')}$
 
   type rc_fluid
 
@@ -77,7 +78,7 @@ module mod_radiative_cooling
   end type rc_fluid
 
   type(rc_fluid)   :: rc_fl
-  !$acc declare create(rc_fl)
+  ${GPU_DECLARE_CREATE('rc_fl')}$
 
   ! Interpolatable tables
 
@@ -454,7 +455,7 @@ module mod_radiative_cooling
 
       rc_gamma_1=rc_gamma-1.d0
       invgam = 1.d0/rc_gamma_1
-      !$acc update device(rc_gamma_1, invgam)
+      ${GPU_UPDATE_DEVICE('rc_gamma_1, invgam')}$
 
     contains
 
@@ -507,7 +508,7 @@ module mod_radiative_cooling
     end subroutine radiative_cooling_init
 
     subroutine radiative_cooling_add_source(qdt,wCT,wCTprim,wnew,x)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
 
     ! w[iw]=w[iw]+qdt*S[wCT,x] where S is the source based on wCT within ixO
       double precision, intent(in) :: qdt, wCT(nw_phys), wCTprim(nw_phys)
@@ -520,7 +521,7 @@ module mod_radiative_cooling
     end subroutine radiative_cooling_add_source
 
     subroutine floortemperature(qdt,wCT,wnew,x,fl)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
     !  Force minimum temperature to a fixed temperature
       double precision, intent(in)    :: qdt, wCT(nw_phys)
       double precision, intent(inout) :: wnew(nw_phys)
@@ -538,7 +539,7 @@ module mod_radiative_cooling
     end subroutine floortemperature
 
     subroutine cool_exact(qdt,wCT,wCTprim,wnew,x,fl)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
     !  Cooling routine using exact integration method from Townsend 2009
       double precision, intent(in)    :: qdt, wCT(nw_phys), wCTprim(nw_phys), x(1:ndim)
       double precision, intent(inout) :: wnew(nw_phys)
@@ -594,7 +595,7 @@ module mod_radiative_cooling
     end subroutine cool_exact
 
     subroutine calc_l_extended (tpoint, lpoint,fl)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
     !  Calculate l for t beyond tcoolmax
     !  Assumes Bremsstrahlung for the interpolated tables
     !  Uses the power law for piecewise power laws
@@ -609,7 +610,7 @@ module mod_radiative_cooling
     subroutine findL (tpoint,Lpoint,fl)
     !  Fast search option to find correct point 
     !  in cooling curve
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
 
       double precision,intent(IN)   :: tpoint
       double precision, intent(OUT) :: Lpoint
@@ -628,7 +629,7 @@ module mod_radiative_cooling
 
     subroutine findY (tpoint,Ypoint,fl)
     !  Fast search option to find correct point in cooling time (TEF)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
 
       double precision,intent(IN)   :: tpoint
       double precision, intent(OUT) :: Ypoint
@@ -651,7 +652,7 @@ module mod_radiative_cooling
     !  from temporal evolution function. Only possible this way because T is a monotonously
     !  decreasing function for the interpolated tables
     !  Uses eq. A7 from Townsend 2009 for piecewise power laws
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
 
       double precision,intent(OUT)   :: tpoint
       double precision, intent(IN) :: Ypoint
@@ -685,7 +686,7 @@ module mod_radiative_cooling
     end subroutine findT
 
     subroutine getvar_cooling_exact(qdt, wCT, w, x, coolrate, fl)
-      !$acc routine seq
+      ${GPU_ROUTINE_SEQ()}$
       ! Calculates cooling rate using the exact cooling method,
       ! for usage in eg. source_terms subroutine.
       ! The TEF must be known, so this routine can only be used

--- a/src/physics/mod_random_heating.fpp
+++ b/src/physics/mod_random_heating.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 ! This module is for imposing randomized heating in 3D setup
 ! Users can define the parameters "trelax,tramp,ntimes,vlim^D,periods,variation,nwaves" in the mod_usr.t file.
 
@@ -19,7 +20,7 @@ module mod_random_heating
 
   double precision, allocatable :: va1(:), va2(:), va3(:)
   double precision, allocatable :: dtimearr(:),timearray(:)
-  !$acc declare create(va1,va2,va3,dtimearr,timearray)
+  ${GPU_DECLARE_CREATE('va1,va2,va3,dtimearr,timearray')}$
 
   double precision :: periods=300.d0
   double precision :: variation=75.d0
@@ -32,8 +33,8 @@ module mod_random_heating
 
   double precision :: trelax=10.d0
   double precision :: tramp=5.d0
-  !$acc declare create(vlim1,vlim2,vlim3)
-  !$acc declare create(trelax,tramp,ntimes)
+  ${GPU_DECLARE_CREATE('vlim1,vlim2,vlim3')}$
+  ${GPU_DECLARE_CREATE('trelax,tramp,ntimes')}$
 
 
   contains
@@ -59,12 +60,12 @@ module mod_random_heating
     use mod_global_parameters
 
     call rh_read_params(par_files)
-    !$acc update device(trelax,tramp,ntimes,vlim1,vlim2,vlim3)
+    ${GPU_UPDATE_DEVICE('trelax,tramp,ntimes,vlim1,vlim2,vlim3')}$
 
   end subroutine rh_init
 
   subroutine rh_source(qt,lQgrid,x)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
 
     double precision, intent(in)    :: qt
@@ -144,7 +145,7 @@ module mod_random_heating
       call MPI_BCAST(timearray,ntimes,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
       call MPI_BCAST(dtimearr,ntimes,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
     endif
-    !$acc update device(timearray,dtimearr)
+    ${GPU_UPDATE_DEVICE('timearray,dtimearr')}$
 
     ! spatial distribution
   
@@ -164,8 +165,8 @@ module mod_random_heating
       call MPI_BCAST(va1,vx1,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
       call MPI_BCAST(va2,vx2,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
       call MPI_BCAST(va3,vx3,MPI_DOUBLE_PRECISION,0,icomm,ierrmpi)
-    endif 
-    !$acc update device(va1,va2,va3)
+    endif
+    ${GPU_UPDATE_DEVICE('va1,va2,va3')}$
 
   contains
 

--- a/src/physics/mod_random_heating.fpp
+++ b/src/physics/mod_random_heating.fpp
@@ -65,8 +65,8 @@ module mod_random_heating
   end subroutine rh_init
 
   subroutine rh_source(qt,lQgrid,x)
-    ${GPU_ROUTINE_SEQ()}$
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
 
     double precision, intent(in)    :: qt
     double precision, intent(inout) :: lQgrid

--- a/src/physics/mod_random_heating.fpp
+++ b/src/physics/mod_random_heating.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 ! This module is for imposing randomized heating in 3D setup
 ! Users can define the parameters "trelax,tramp,ntimes,vlim^D,periods,variation,nwaves" in the mod_usr.t file.
 

--- a/src/srhd/mod_con2prim.fpp
+++ b/src/srhd/mod_con2prim.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 module mod_con2prim
 
 use mod_global_parameters
@@ -12,14 +13,14 @@ implicit none
   double precision, public         :: tolernr   = 1.0d-9
   double precision, public         :: dmaxvel   = 1.0d-7
   
-  !$acc declare copyin(maxitnr,absaccnr,tolernr,dmaxvel)
+  ${GPU_DECLARE_COPYIN('maxitnr,absaccnr,tolernr,dmaxvel')}$
 
 
 contains 
 
   !> con2prim: (D,S**2,tau) --> compute auxiliaries lfac and xi
   pure subroutine con2prim_eos(lfac,xi,myd,myssqr,mytau)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(in)    :: myd, myssqr, mytau
     double precision, intent(inout) :: lfac, xi
 
@@ -48,7 +49,7 @@ contains
 
   !> SRHD iteration solves for p via NR, and then gives xi as output
   pure subroutine con2primHydro_eos(lfac,xi,d,sqrs,tau)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(out) :: xi,lfac
     double precision, intent(in)  :: d,sqrs,tau
 
@@ -219,7 +220,7 @@ contains
   !> pointwise evaluations used in con2prim
   !> compute pointwise value for pressure p and dpdxi
   pure subroutine FuncPressure_eos(xicurrent,lfac,d,dlfacdxi,p,dpdxi)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(in)         :: xicurrent,lfac,d,dlfacdxi
     double precision, intent(out)        :: p,dpdxi
     ! .. local ..
@@ -249,7 +250,7 @@ contains
 
   !> con2prim: (D,S**2,tau) --> compute auxiliaries lfac and xi
   pure subroutine con2prim(lfac,xi,myd,myssqr,mytau)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(in)    :: myd, myssqr, mytau
     double precision, intent(inout) :: lfac, xi
 
@@ -274,7 +275,7 @@ contains
 
 
   pure subroutine funcd(xi,f,df,mylfac,d,ssqr,tau)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(in)  :: xi,d,ssqr,tau
     double precision, intent(out) :: f,df,mylfac
 
@@ -297,7 +298,7 @@ contains
 
   !> SRHD iteration solves for p via NR, and then gives xi as output
   pure subroutine con2primHydro(lfac,xi,d,sqrs,tau)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     double precision, intent(out) :: xi,lfac
     double precision, intent(in)  :: d,sqrs,tau
 
@@ -453,7 +454,7 @@ contains
   !> pointwise evaluations used in con2prim
   !> compute pointwise value for pressure p and dpdxi
   pure subroutine FuncPressure(xicurrent,lfac,d,dlfacdxi,p,dpdxi)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
 
     double precision, intent(in)         :: xicurrent,lfac,d,dlfacdxi
     double precision, intent(out)        :: p,dpdxi

--- a/src/srhd/mod_con2prim.fpp
+++ b/src/srhd/mod_con2prim.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 module mod_con2prim
 
 use mod_global_parameters

--- a/src/srhd/mod_srhd_templates.fpp
+++ b/src/srhd/mod_srhd_templates.fpp
@@ -1,4 +1,6 @@
+#:mute
 #:include "../mod_gpu_directives.fpp"
+#:endmute
 #:if PHYS == 'srhd'
 
 #:if defined('N_TRACER')

--- a/src/srhd/mod_srhd_templates.fpp
+++ b/src/srhd/mod_srhd_templates.fpp
@@ -1,3 +1,4 @@
+#:include "../mod_gpu_directives.fpp"
 #:if PHYS == 'srhd'
 
 #:if defined('N_TRACER')
@@ -14,62 +15,62 @@
   
   !> Whether synge eos is used
   logical, public                         :: srhd_eos = .false.
-  !$acc declare copyin(srhd_eos)
+  ${GPU_DECLARE_COPYIN('srhd_eos')}$
 
   !> Index of the density (in the w array) as primitive or conserved
   integer, public                         :: rho_
   integer, public                         :: d_
-  !$acc declare create(rho_,d_)
+  ${GPU_DECLARE_CREATE('rho_,d_')}$
 
   !> Indices of the momentum density
   integer, allocatable, public            :: mom(:)
-  !$acc declare create(mom)
+  ${GPU_DECLARE_CREATE('mom')}$
 
 #:if defined('N_TRACER')
   !> Indices of the tracers
   integer, public                         :: tracer(${N_TRACER_}$)
-  !$acc declare create(tracer)
+  ${GPU_DECLARE_CREATE('tracer')}$
 #:endif
 
   !> Index of the energy density
   integer, public                         :: e_
-  !$acc declare create(e_)
+  ${GPU_DECLARE_CREATE('e_')}$
 
   !> Index of the gas pressure should equal e_
   integer, public                         :: p_
-  !$acc declare create(p_)
+  ${GPU_DECLARE_CREATE('p_')}$
 
   !> Index of the Lorentz factor
   integer, public     :: lfac_
-  !$acc declare create(lfac_)
+  ${GPU_DECLARE_CREATE('lfac_')}$
 
   !> Index of the inertia
   integer, public     :: xi_
-  !$acc declare create(xi_)
+  ${GPU_DECLARE_CREATE('xi_')}$
 
   !> Number of tracer species
   integer, public                         :: srhd_n_tracer = 0
-  !$acc declare copyin(srhd_n_tracer)
+  ${GPU_DECLARE_COPYIN('srhd_n_tracer')}$
 
   !> The adiabatic index
   double precision, public                :: srhd_gamma = 5.d0/3.0d0
-  !$acc declare copyin(srhd_gamma)
+  ${GPU_DECLARE_COPYIN('srhd_gamma')}$
 
   !> derived values from adiabatic index 
   double precision, public                :: gamma_1,inv_gamma_1,gamma_to_gamma_1
-  !$acc declare copyin(gamma_1,inv_gamma_1,gamma_to_gamma_1)
+  ${GPU_DECLARE_COPYIN('gamma_1,inv_gamma_1,gamma_to_gamma_1')}$
 
   !> Helium abundance over Hydrogen
   double precision, public  :: He_abundance=0.1d0
-  !$acc declare copyin(He_abundance)
+  ${GPU_DECLARE_COPYIN('He_abundance')}$
 
   !> Whether particles module is added
   logical, public                         :: srhd_particles = .false.
-  !$acc declare copyin(srhd_particles)
+  ${GPU_DECLARE_COPYIN('srhd_particles')}$
 
   !> switch for source user
   logical, public                         :: srhd_source_usr = .false.
-  !$acc declare copyin(srhd_source_usr)
+  ${GPU_DECLARE_COPYIN('srhd_source_usr')}$
 
 #:enddef
 
@@ -89,11 +90,7 @@
 111    close(unitpar)
     end do
 
-#ifdef _OPENACC
-    !$acc update device(srhd_eos, &
-    !$acc&     srhd_gamma, srhd_n_tracer, &
-    !$acc&     He_abundance, srhd_source_usr)
-#endif
+    ${GPU_UPDATE_DEVICE('srhd_eos, srhd_gamma, srhd_n_tracer, He_abundance, srhd_source_usr')}$
 
   end subroutine read_params
 #:enddef
@@ -122,7 +119,7 @@
     unit_time=unit_length/unit_velocity
     unit_mass=unit_density*unit_length**3
 
-    !$acc update device(unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass)
+    ${GPU_UPDATE_DEVICE('unit_density, unit_numberdensity, unit_temperature, unit_pressure, unit_velocity, unit_length, unit_time, unit_mass')}$
   end subroutine phys_units
 #:enddef
   
@@ -142,7 +139,7 @@
     gamma_1=srhd_gamma-1.0d0
     inv_gamma_1=1.0d0/gamma_1
     gamma_to_gamma_1=srhd_gamma/gamma_1
-    !$acc update device(gamma_1,inv_gamma_1,gamma_to_gamma_1)
+    ${GPU_UPDATE_DEVICE('gamma_1,inv_gamma_1,gamma_to_gamma_1')}$
 
     phys_internal_e=.false.
     phys_partial_ionization=.false.
@@ -151,41 +148,41 @@
     ! Whether diagonal ghost cells are required for the physics
     phys_req_diagonal = .false.
 
- !$acc update device(physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,phys_req_diagonal)
+    ${GPU_UPDATE_DEVICE('physics_type, phys_energy, phys_total_energy, phys_internal_e, phys_gamma, phys_partial_ionization,need_global_cmax,phys_req_diagonal')}$
 
     use_particles = srhd_particles
 
     ! Determine flux variables
     rho_ = var_set_rho()
     d_=rho_
-    !$acc update device(rho_,d_)
+    ${GPU_UPDATE_DEVICE('rho_,d_')}$
 
     allocate(mom(ndir))
     mom(:) = var_set_momentum(ndir)
-    !$acc update device(mom)
+    ${GPU_UPDATE_DEVICE('mom')}$
 
     ! Set index of energy variable
     e_ = var_set_energy()
     p_ = e_
-    !$acc update device(e_,p_)
+    ${GPU_UPDATE_DEVICE('e_,p_')}$
 
     ! Register tracer fields
 #:if defined('N_TRACER')
     #:for i in range(1, N_TRACER_+1)
         tracer(${i}$) = var_set_fluxvar("trc", "trp", ${i}$, need_bc=.false.)
     #:endfor
-    !$acc update device(tracer)
+    ${GPU_UPDATE_DEVICE('tracer')}$
 #:endif
 
     ! Set index for auxiliary variables
     ! MUST be after the possible tracers (which have fluxes)
     xi_  = var_set_auxvar('xi','xi')
     lfac_= var_set_auxvar('lfac','lfac')
-    !$acc update device(xi_,lfac_)
+    ${GPU_UPDATE_DEVICE('xi_,lfac_')}$
 
     ! set number of variables which need update ghostcells
     nwgc=nwflux+nwaux
-    !$acc update device(nwgc)
+    ${GPU_UPDATE_DEVICE('nwgc')}$
 
     ! Define custom flux types:
     if (.not. allocated(flux_type)) then
@@ -194,7 +191,7 @@
     else if (any(shape(flux_type) /= [ndir, nw_flux])) then
        call mpistop("phys_check error: flux_type has wrong shape")
     end if
-    !$acc update device(flux_type)
+    ${GPU_UPDATE_DEVICE('flux_type')}$
 
 ! use cycle, needs to be dealt with:    
 !    ! Initialize particles module
@@ -208,7 +205,7 @@
 
 #:def phys_get_dt()
   subroutine phys_get_dt(w, x, dx, dtnew)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)   :: w(nw_phys), x(1:ndim), dx(1:ndim)
     real(dp), intent(out)  :: dtnew
 
@@ -224,7 +221,7 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
@@ -256,7 +253,7 @@ end subroutine addsource_local
 
 #:def to_primitive()
   pure subroutine to_primitive(u)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     use mod_con2prim
     real(dp), intent(inout) :: u(nw_phys)
 
@@ -295,7 +292,7 @@ end subroutine addsource_local
 
 #:def to_conservative()  
   pure subroutine to_conservative(u)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: u(nw_phys)
 
     real(dp) :: rho,rhoh,pth
@@ -333,7 +330,7 @@ end subroutine addsource_local
 #:def get_flux()
   subroutine get_flux(u, xC, flux_dim, flux)
     use mod_global_parameters, only:cmax_global
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: u(nw_phys)
     real(dp), intent(in)  :: xC(1:ndim)
     integer, intent(in)   :: flux_dim
@@ -372,7 +369,7 @@ end subroutine addsource_local
 !> Returns maximum local signal speed from primitive state u in direction flux_dim;
 !> used in LLF/TVDLF flux estimation.
 pure real(dp) function get_cmax(u, x, flux_dim) result(wC)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: u(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
   integer, intent(in)   :: flux_dim
@@ -421,7 +418,7 @@ end function get_cmax
 
 #:def get_rho()
   pure real(dp) function get_rho(w, x) result(rho)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)  :: w(nw_phys)
     real(dp), intent(in)  :: x(1:ndim)
 
@@ -431,7 +428,7 @@ end function get_cmax
 
 #:def get_pthermal()
 pure real(dp) function get_pthermal(w, x) result(pth)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: w(nw_phys)
   real(dp), intent(in)  :: x(1:ndim)
 
@@ -441,7 +438,7 @@ end function get_pthermal
 
 #:def get_Rfactor()
 pure real(dp) function get_Rfactor() result(Rfactor)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
 
     ! TODO: only for local rad loss
 end function get_Rfactor
@@ -450,7 +447,7 @@ end function get_Rfactor
 #:def estimate_speeds_minmax()
 !> used in HLL flux estimation.
 subroutine estimate_speeds_minmax(uL, uR, xC, flux_dim, wL, wR)
-  !$acc routine seq
+  ${GPU_ROUTINE_SEQ()}$
   real(dp), intent(in)  :: uL(nw_phys), uR(nw_phys)
   real(dp), intent(in)  :: xC(ndim)
   integer, intent(in)   :: flux_dim

--- a/src/srhd/mod_srhd_templates.fpp
+++ b/src/srhd/mod_srhd_templates.fpp
@@ -221,10 +221,10 @@
 #:def addsource_local()
 subroutine addsource_local(qdt, dtfactor, qtC, wCT, wCTprim, qt, wnew, x, dr, &
     qsourcesplit)
-  ${GPU_ROUTINE_SEQ()}$
 #:if defined('SOURCE_USR')
   use mod_usr, only: addsource_usr
 #:endif
+  ${GPU_ROUTINE_SEQ()}$
 
   real(dp), intent(in)     :: qdt, dtfactor, qtC, qt
   real(dp), intent(in)     :: wCT(nw_phys), wCTprim(nw_phys)
@@ -253,8 +253,8 @@ end subroutine addsource_local
 
 #:def to_primitive()
   pure subroutine to_primitive(u)
-    ${GPU_ROUTINE_SEQ()}$
     use mod_con2prim
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(inout) :: u(nw_phys)
 
     real(dp) :: rho,rhoh,pth,E

--- a/tests/ffhd/TI3D/mod_usr.fpp
+++ b/tests/ffhd/TI3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 !> thermal instability test problem copied from amrvac/tests/demo/thermal_instability_HD/
 module mod_usr
   use mod_amrvac
@@ -6,7 +10,7 @@ module mod_usr
   implicit none
 
   double precision :: scale, radius
-  !$acc declare create(scale, radius)
+  ${GPU_DECLARE_CREATE('scale, radius')}$
 
 contains
 
@@ -103,7 +107,7 @@ contains
 
 
   pure real(dp) function gravity_field(wCT, x, idim) result(field)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)    :: wCT(nw_phys)
     real(dp), intent(in)    :: x(1:ndim)
     integer, value, intent(in)     :: idim
@@ -115,10 +119,10 @@ contains
   end function gravity_field
 
   subroutine addsource_usr(qdt, qt, wCT, wCTprim, wnew, x, qsourcesplit)
-    !$acc routine seq
     #:if defined('COOLING')
     use mod_radiative_cooling, only: rc_fl, getvar_cooling_exact
     #:endif
+    ${GPU_ROUTINE_SEQ()}$
 
     double precision, intent(in) :: qdt, qt
     double precision, intent(in) :: wCT(nw_phys), wCTprim(nw_phys) 

--- a/tests/ffhd/quadrupolar3D/mod_usr.fpp
+++ b/tests/ffhd/quadrupolar3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
 
     use mod_amrvac
@@ -6,14 +10,14 @@ module mod_usr
     implicit none
 
     double precision, allocatable :: pbc(:),rbc(:)
-    !$acc declare create(pbc,rbc)
+    ${GPU_DECLARE_CREATE('pbc,rbc')}$
     double precision :: usr_grav
     double precision :: heatunit,gzone,SRadius,dya
     double precision, allocatable :: pa(:),ra(:)
     integer, parameter :: jmax=5000
-    !$acc declare create(usr_grav,SRadius,pbc,rbc)
+    ${GPU_DECLARE_CREATE('usr_grav,SRadius,pbc,rbc')}$
     double precision :: B0,kx,y0,lQ0,bQ0
-    !$acc declare create(lQ0,bQ0)
+    ${GPU_DECLARE_CREATE('lQ0,bQ0')}$
   
   contains
 
@@ -58,17 +62,17 @@ module mod_usr
       dya=(2.d0*gzone+xprobmax3-xprobmin3)/dble(jmax) !< cells size of high-resolution 1D solar atmosphere
 
       usr_grav=-2.74d4*unit_length/unit_velocity**2 !< solar gravity
-      !$acc update device(usr_grav)
+      ${GPU_UPDATE_DEVICE('usr_grav')}$
 
       SRadius=69.61d0 !< Solar radius
-      !$acc update device(SRadius)
+      ${GPU_UPDATE_DEVICE('SRadius')}$
 
       lQ0=lQ0/heatunit
-      !$acc update device(lQ0)
+      ${GPU_UPDATE_DEVICE('lQ0')}$
       bQ0=bQ0/heatunit
-      !$acc update device(bQ0)
+      ${GPU_UPDATE_DEVICE('bQ0')}$
 
-      !$acc update device(xprobmin1,xprobmax1,xprobmin2,xprobmax2,xprobmin3,xprobmax3)
+      ${GPU_UPDATE_DEVICE('xprobmin1,xprobmax1,xprobmin2,xprobmax2,xprobmin3,xprobmax3')}$
 
       call generateTV()
       call inithdstatic()
@@ -157,7 +161,7 @@ module mod_usr
         pbc(ibc)=pa(na)+(one-cos(dpi*res/dya))/two*(pa(na+1)-pa(na))
       end do
       deallocate(ya,gg,Ta)
-      !$acc update device(rbc,pbc)
+      ${GPU_UPDATE_DEVICE('rbc,pbc')}$
     end subroutine inithdstatic
 
     subroutine initonegrid_usr(ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,ixImax3,&
@@ -215,7 +219,7 @@ module mod_usr
 
     subroutine specialbound_usr(qt, ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
         ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB, w, x)
-        !$acc routine vector
+        ${GPU_ROUTINE_VECTOR()}$
 
         integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
         ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB
@@ -233,7 +237,7 @@ module mod_usr
         select case(iB)
         case(5)
 
-        !$acc loop collapse(3) vector
+        ${GPU_LOOP_VECTOR("collapse(3)")}$
         do ix3=ixOmin3,ixOmax3
             do ix2=ixOmin2,ixOmax2
             do ix1=ixOmin1,ixOmax1
@@ -258,7 +262,7 @@ module mod_usr
         ! case(6)
 
         ! ! to include ix3 into loop, perhaps precompute?
-        ! !$acc loop collapse(2) vector
+        ! ${GPU_LOOP_VECTOR("collapse(2)")}$
         !   do ix2=ixOmin2,ixOmax2
         !     do ix1=ixOmin1,ixOmax1
 
@@ -293,7 +297,7 @@ module mod_usr
    end subroutine specialbound_usr
 
    pure real(dp) function gravity_field(wCT, x, idim) result(field)
-     !$acc routine seq
+     ${GPU_ROUTINE_SEQ()}$
      real(dp), intent(in)    :: wCT(nw_phys)
      real(dp), intent(in)    :: x(1:ndim)
      integer, value, intent(in)     :: idim
@@ -307,8 +311,8 @@ module mod_usr
    end function gravity_field
 
   subroutine addsource_usr(qdt, qt, wCT, wCTprim, wnew, x, qsourcesplit)
-    !$acc routine seq
     use mod_random_heating, only: rh_source
+    ${GPU_ROUTINE_SEQ()}$
 
     double precision, intent(in) :: qdt, qt
     double precision, intent(in) :: wCT(nw_phys), wCTprim(nw_phys) 

--- a/tests/ffhd/solar_atmosphere3D/mod_usr.fpp
+++ b/tests/ffhd/solar_atmosphere3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
     use mod_amrvac
     use mod_physics
@@ -5,15 +9,15 @@ module mod_usr
     implicit none
 
     double precision, allocatable :: pbc(:),rbc(:)
-    !$acc declare create(pbc,rbc)
+    ${GPU_DECLARE_CREATE('pbc,rbc')}$
     double precision :: usr_grav,trelax
     double precision :: heatunit,gzone,SRadius,dya
     double precision, allocatable :: pa(:),ra(:)
     integer, parameter :: jmax=5000
     double precision :: dh, Bh, dv, Bv, xv, dp1
     double precision :: ch, cv, dh1, dv1
-    !$acc declare create(dh,Bh,dv,Bv,xv,dp1,ch,cv,dh1,dv1)
-    !$acc declare create(usr_grav,SRadius,pbc,rbc)
+    ${GPU_DECLARE_CREATE('dh,Bh,dv,Bv,xv,dp1,ch,cv,dh1,dv1')}$
+    ${GPU_DECLARE_CREATE('usr_grav,SRadius,pbc,rbc')}$
   
   contains
 
@@ -36,7 +40,7 @@ module mod_usr
 
       call set_coordinate_system("Cartesian_3D")
       call usr_params_read(par_files)
-      !$acc update device(dh,Bh,dv,Bv,xv,dp1)
+      ${GPU_UPDATE_DEVICE('dh,Bh,dv,Bv,xv,dp1')}$
   
       unit_length        = 1.d9 !< cm
       unit_temperature   = 1.d6 !< K
@@ -56,16 +60,16 @@ module mod_usr
       dya=(2.d0*gzone+xprobmax3-xprobmin3)/dble(jmax) !< cells size of high-resolution 1D solar atmosphere
 
       usr_grav=-2.74d4*unit_length/unit_velocity**2 !< solar gravity
-      !$acc update device(usr_grav)
+      ${GPU_UPDATE_DEVICE('usr_grav')}$
 
       SRadius=69.61d0 !< Solar radius
-      !$acc update device(SRadius)
+      ${GPU_UPDATE_DEVICE('SRadius')}$
 
       ch = (Bh*dh**3.d0)*0.5d0
       cv = (Bv*dv**3.d0)*0.5d0
       dh1 = dh + dp1
       dv1 = dv + dp1
-      !$acc update device(ch,cv,dh1,dv1)
+      ${GPU_UPDATE_DEVICE('ch,cv,dh1,dv1')}$
 
       call inithdstatic
 
@@ -142,7 +146,7 @@ module mod_usr
         pbc(ibc)=pa(na)+(one-cos(dpi*res/dya))/two*(pa(na+1)-pa(na))
       end do
       deallocate(ya,gg,Ta)
-      !$acc update device(rbc,pbc)
+      ${GPU_UPDATE_DEVICE('rbc,pbc')}$
     end subroutine inithdstatic
 
     subroutine initonegrid_usr(ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,ixImax3,&
@@ -216,7 +220,7 @@ module mod_usr
 
     subroutine specialbound_usr(qt, ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
         ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB, w, x)
-        !$acc routine vector
+        ${GPU_ROUTINE_VECTOR()}$
 
         integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
         ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB
@@ -234,7 +238,7 @@ module mod_usr
         select case(iB)
         case(5)
 
-        !$acc loop collapse(3) vector
+        ${GPU_LOOP_VECTOR("collapse(3)")}$
         do ix3=ixOmin3,ixOmax3
             do ix2=ixOmin2,ixOmax2
             do ix1=ixOmin1,ixOmax1
@@ -259,11 +263,11 @@ module mod_usr
         ! case(6)
 
         ! ! to include ix3 into loop, perhaps precompute?
-        ! !$acc loop collapse(2) vector
+        ! ${GPU_LOOP_VECTOR("collapse(2)")}$
         ! do ix2=ixOmin2,ixOmax2
         ! do ix1=ixOmin1,ixOmax1
 
-        !   !$acc routine seq
+        !   ${GPU_ROUTINE_SEQ()}$
         !   tmp = 0.d0
         !   do ix3=ixOmin3,ixOmax3
         !     gravity = 0.5d0*(gravity_field(w(ix1,ix2,ix3,:), x(ix1,ix2,ix3,:), 3) + &
@@ -274,7 +278,7 @@ module mod_usr
 
         ! end do 
         ! end do
-        ! !$acc loop collapse(2) vector
+        ! ${GPU_LOOP_VECTOR("collapse(2)")}$
         !   do ix2=ixOmin2,ixOmax2
         !     do ix1=ixOmin1,ixOmax1
 
@@ -309,7 +313,7 @@ module mod_usr
    end subroutine specialbound_usr
 
    pure real(dp) function gravity_field(wCT, x, idim) result(field)
-     !$acc routine seq
+     ${GPU_ROUTINE_SEQ()}$
      real(dp), intent(in)    :: wCT(nw_phys)
      real(dp), intent(in)    :: x(1:ndim)
      integer, value, intent(in)     :: idim

--- a/tests/hd/KH3D-SMR/mod_usr.fpp
+++ b/tests/hd/KH3D-SMR/mod_usr.fpp
@@ -107,16 +107,12 @@ contains
   subroutine usr_refine_grid(igrid,level,ixGmin1,ixGmin2,ixGmin3,&
     ixGmax1,ixGmax2,ixGmax3,ixmin1,ixmin2,ixmin3,ixmax1,ixmax2,ixmax3,&
     qt,w,x,refine,coarsen)
-#ifdef _CRAYFTN
-#ifdef _OPENACC
-    ! The Cray compiler fails when trying to inline this routine, for now
+#if defined(_CRAYFTN) && (defined(_OPENACC) || defined(_OPENMP))
     ! disable inlining for Cray
     !dir$ inlinenever usr_refine_grid
 #endif
-#endif
-    !$acc routine vector
-
     use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
 
     ! Enforce additional refinement or coarsening
     ! One can use the coordinate info in x and/or time qt=t_n and w(t_n) values w.

--- a/tests/hd/KH3D-SMR/mod_usr.fpp
+++ b/tests/hd/KH3D-SMR/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -142,7 +146,7 @@ contains
 
 
     has_interface = .false.
-    !$acc loop vector collapse(3) reduction(.or.:has_interface)
+    ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:has_interface)")}$
     do ix3 = ixmin3, ixmax3
        do ix2 = ixmin2, ixmax2
           do ix1 = ixmin1, ixmax1

--- a/tests/hd/RT3D/mod_usr.fpp
+++ b/tests/hd/RT3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_physics
   use mod_amrvac
@@ -17,7 +21,7 @@ contains
   end subroutine usr_init
 
   pure real(dp) function gravity_field(wCT, x, idim) result(field)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)    :: wCT(nw_phys)
     real(dp), intent(in)    :: x(1:ndim)
     integer, value, intent(in)     :: idim

--- a/tests/hd/TRML/mod_usr.fpp
+++ b/tests/hd/TRML/mod_usr.fpp
@@ -352,13 +352,12 @@ contains
     ixGmin1, ixGmin2, ixGmin3, ixGmax1, ixGmax2, ixGmax3,&
     ixmin1,  ixmin2,  ixmin3,  ixmax1,  ixmax2,  ixmax3,&
     qt, w, x, refine, coarsen)
-#ifdef _OPENACC
-! NOTE: The Cray compiler fails when trying to inline this routine, for now
-!   disable inlining for Cray.
+#if defined(_CRAYFTN) && (defined(_OPENACC) || defined(_OPENMP))
+    ! disable inlining for Cray
     !dir$ inlinenever usr_refine_grid
 #endif
-    !$acc routine seq
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
     implicit none
     integer, intent(in) :: igrid, level
     integer, intent(in) :: ixGmin1, ixGmin2, ixGmin3, ixGmax1, ixGmax2, ixGmax3

--- a/tests/hd/TRML/mod_usr.fpp
+++ b/tests/hd/TRML/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
 
   use mod_amrvac
@@ -44,9 +48,9 @@ module mod_usr
 ! (4, n_modes, n_modes, 2:3)
   double precision, dimension(:,:,:,:), allocatable :: rand_1
 
-!$acc declare create(P, rho_H, rho_C, z0, d_z, sig_z, v_H, v_C, v_sh, mode_root, n_modes)
-!$acc declare create(L, v_per, f_til, refine_z)
-!$acc declare create(rand_1)
+  ${GPU_DECLARE_CREATE('P, rho_H, rho_C, z0, d_z, sig_z, v_H, v_C, v_sh, mode_root, n_modes')}$
+  ${GPU_DECLARE_CREATE('L, v_per, f_til, refine_z')}$
+  ${GPU_DECLARE_CREATE('rand_1')}$
 
 contains
 
@@ -190,9 +194,9 @@ contains
     T_C = T_H/chi
     T_mix = sqrt(T_C*T_H)
 
-!$acc update device(P, rho_H, rho_C, z0, d_z, sig_z, v_H, v_C, v_sh, mode_root, n_modes)
-!$acc update device(L, v_per, f_til, refine_z)
-!$acc update device(rand_1)
+    ${GPU_UPDATE_DEVICE('P, rho_H, rho_C, z0, d_z, sig_z, v_H, v_C, v_sh, mode_root, n_modes')}$
+    ${GPU_UPDATE_DEVICE('L, v_per, f_til, refine_z')}$
+    ${GPU_UPDATE_DEVICE('rand_1')}$
 
     if (mype == 0) call print_params()
   end subroutine set_parameters_usr
@@ -291,10 +295,10 @@ contains
       ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3,&
       ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3,&
       iB, w, x)
-!$acc routine vector
     ! use mod_physics, only: to_conservative, to_primitive
     use mod_global_parameters
     use mod_physics
+    ${GPU_ROUTINE_VECTOR()}$
     implicit none
     integer, intent(in) :: ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3
     integer, intent(in) :: ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3
@@ -316,7 +320,7 @@ contains
 !   moment, we apply the boundary condition in conservative form.
     select case(iB)
     case(5)
-!$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
       do ix2 = ixOmin2, ixOmax2
       do ix1 = ixOmin1, ixOmax1
@@ -330,7 +334,7 @@ contains
       end do
       end do
     case(6)
-!$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
       do ix2 = ixOmin2, ixOmax2
       do ix1 = ixOmin1, ixOmax1

--- a/tests/hd/Woodward_Collela/mod_usr.fpp
+++ b/tests/hd/Woodward_Collela/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
 
   use mod_amrvac
@@ -11,8 +15,8 @@ module mod_usr
   double precision :: mx_post,my_post,epost,epre
   double precision :: rho_3,xpos_3,zpos_3,rad_3
 
-!$acc declare create(rho_1,rho_2,p_1,p_2,angle_frac,x_offset,mx_post,my_post,epost,epre)
-!$acc declare create(rho_3,xpos_3,zpos_3,rad_3)
+  ${GPU_DECLARE_CREATE('rho_1,rho_2,p_1,p_2,angle_frac,x_offset,mx_post,my_post,epost,epre')}$
+  ${GPU_DECLARE_CREATE('rho_3,xpos_3,zpos_3,rad_3')}$
 
 contains
 
@@ -70,8 +74,8 @@ contains
     my_post=-rho_2*8.25d0*dcos(dpi*angle_frac)
     epre=p_1/(hd_gamma-1.0d0)
     epost=p_2/(hd_gamma-1.0d0)+(mx_post**2+my_post**2)/(2.0d0*rho_2)
-!$acc update device(hd_gamma,angle_frac,x_offset,rho_1,rho_2,p_1,p_2,mx_post,my_post,epre,epost)
-!$acc update device(rad_3,rho_3,xpos_3,zpos_3)
+    ${GPU_UPDATE_DEVICE('hd_gamma,angle_frac,x_offset,rho_1,rho_2,p_1,p_2,mx_post,my_post,epre,epost')}$
+    ${GPU_UPDATE_DEVICE('rad_3,rho_3,xpos_3,zpos_3')}$
 
     if (mype == 0) call print_params()
   end subroutine set_parameters_usr
@@ -123,10 +127,10 @@ contains
       ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3,&
       ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3,&
       iB, w, x)
-!$acc routine vector
     ! use mod_physics, only: to_conservative, to_primitive
     use mod_global_parameters
     use mod_physics
+    ${GPU_ROUTINE_VECTOR()}$
     implicit none
     integer, intent(in) :: ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3
     integer, intent(in) :: ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3
@@ -141,7 +145,7 @@ contains
     select case(iB)
     case(1)
       ! implementation of fixed postshock state at left boundary
-!$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
       do ix2 = ixOmin2, ixOmax2
       do ix1 = ixOmin1, ixOmax1
@@ -155,7 +159,7 @@ contains
       end do
     case(3)
       ! implementation of bottom boundary: fixed before x<1/6, solid wall x>=1/6
-!$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
       do ix2 = ixOmin2, ixOmax2
       do ix1 = ixOmin1, ixOmax1
@@ -177,7 +181,7 @@ contains
       end do
     case(4)
       ! implementation of top: pre and post shock states, time dependent
-!$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
       do ix2 = ixOmin2, ixOmax2
       do ix1 = ixOmin1, ixOmax1

--- a/tests/hd/cloud_crushing/mod_usr.fpp
+++ b/tests/hd/cloud_crushing/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -6,7 +10,7 @@ module mod_usr
   ! --- User parameters (code units) ---
   double precision :: ca, mach, chi, rc, eps_rho
   double precision :: x1c, x2c, x3c
-  !$acc declare create(ca, mach)
+  ${GPU_DECLARE_CREATE('ca, mach')}$
 
   ! --- Turbulence ---
   logical :: use_turbulence = .true.
@@ -60,7 +64,7 @@ contains
 
     eps_rho = 0.20d0  ! density gradient across cloud
 
-    !$acc update device(ca, mach)
+    ${GPU_UPDATE_DEVICE('ca, mach')}$
 
     call init_turbulence_modes()
 
@@ -222,8 +226,8 @@ contains
 
   subroutine specialbound_usr(qt, ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,ixImax3,&
                               ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB, w, x)
-    !$acc routine vector
     use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
     integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,ixImax3
     integer, intent(in)             :: ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3
     integer, intent(in)             :: iB
@@ -245,7 +249,7 @@ contains
 
       inv_gamma_m1 = 1.0d0/(hd_gamma - 1.0d0)
 
-      !$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
         do ix2 = ixOmin2, ixOmax2
           do ix1 = ixOmin1, ixOmax1

--- a/tests/hd/cloud_crushing/mod_usr.fpp
+++ b/tests/hd/cloud_crushing/mod_usr.fpp
@@ -277,13 +277,12 @@ contains
   subroutine usr_refine_grid(igrid,level,ixGmin1,ixGmin2,ixGmin3,&
     ixGmax1,ixGmax2,ixGmax3,ixmin1,ixmin2,ixmin3,ixmax1,ixmax2,ixmax3,&
     qt,w,x,refine,coarsen)
-#ifdef _OPENACC
+#if defined(_CRAYFTN) && (defined(_OPENACC) || defined(_OPENMP))
     ! disable inlining for Cray
     !dir$ inlinenever usr_refine_grid
 #endif
-    !$acc routine seq
-
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
 
     ! Enforce additional refinement or coarsening
     ! One can use the coordinate info in x and/or time qt=t_n and w(t_n) values w.

--- a/tests/hd/jet_cloud/mod_usr.fpp
+++ b/tests/hd/jet_cloud/mod_usr.fpp
@@ -1,11 +1,15 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
-  
+
   implicit none
-  
+
   double precision  :: beta, eta_jet, ca, mach, rc
-  !$acc declare create( beta, eta_jet, ca, mach, rc )
+  ${GPU_DECLARE_CREATE('beta, eta_jet, ca, mach, rc')}$
 
 contains
   
@@ -35,7 +39,7 @@ contains
     ! cloud to jet radii ratio
     rc      = 1.5d0
 
-    !$acc update device( beta, eta_jet, ca, mach, rc )
+    ${GPU_UPDATE_DEVICE('beta, eta_jet, ca, mach, rc')}$
     
   end subroutine initglobaldata_usr
 
@@ -117,7 +121,7 @@ contains
 
   subroutine specialbound_usr(qt, ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB, w, x)
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
 
     integer, intent(in)             :: ixImin1,ixImin2,ixImin3,ixImax1,ixImax2,&
        ixImax3, ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3, iB
@@ -138,7 +142,7 @@ contains
 
         inv_gamma_m1 = 1.0d0/(hd_gamma - 1.0d0)
         
-        !$acc loop collapse(3) vector
+        ${GPU_LOOP_VECTOR("collapse(3)")}$
         do ix3=ixOmin3,ixOmax3
            do ix2=ixOmin2,ixOmax2
               do ix1=ixOmin1,ixOmax1

--- a/tests/hd/sphere_advection/mod_usr.fpp
+++ b/tests/hd/sphere_advection/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -6,7 +10,7 @@ module mod_usr
 
   double precision :: rhodens  = 10.0d0
   double precision :: rholight = 1.0d0
-  !$acc declare copyin(rhodens, rholight)
+  ${GPU_DECLARE_COPYIN('rhodens, rholight')}$
   double precision :: p        = 10.0d0
   double precision :: rsphere  = 0.25d0
   double precision :: v1 = 1.0d0, v2 = 1.0d0, v3 = 1.0d0
@@ -69,7 +73,7 @@ contains
     qt,w,x,refine,coarsen)
 
     use mod_global_parameters
-    !$acc routine vector
+    ${GPU_ROUTINE_VECTOR()}$
     ! Enforce additional refinement or coarsening
     ! One can use the coordinate info in x and/or time qt=t_n and w(t_n) values w.
 
@@ -96,7 +100,7 @@ contains
     logical                         :: has_sphere
 
     has_sphere = .false.
-    !$acc loop collapse(3) reduction(.or.:has_sphere)
+    ${GPU_LOOP_VECTOR("collapse(3) reduction(.or.:has_sphere)")}$
     do ix3 = ixmin3, ixmax3
        do ix2 = ixmin2, ixmax2
           do ix1 = ixmin1, ixmax1

--- a/tests/mhd/KH3D/mod_usr.fpp
+++ b/tests/mhd/KH3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -108,7 +112,7 @@ contains
 
   !> analytical fomula for the unit vectors along B
   pure real(dp) function bfield(x, idim) result(field)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)    :: x(1:ndim)
     integer, value, intent(in)     :: idim
 

--- a/tests/mhd/Orszag-Tang-cooling/mod_usr.fpp
+++ b/tests/mhd/Orszag-Tang-cooling/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -6,7 +10,7 @@ module mod_usr
 
   double precision:: v0,rho0,p0,T0,pbeta0,b0,mach0
 
-!$acc declare create(v0,rho0,p0,T0,pbeta0,b0,mach0)
+  ${GPU_DECLARE_CREATE('v0,rho0,p0,T0,pbeta0,b0,mach0')}$
 
 contains
 
@@ -52,7 +56,7 @@ contains
     endif
     v0=mach0*dsqrt(mhd_gamma*p0/rho0)
 
-!$acc update device(v0,rho0,p0,T0,pbeta0,b0,mach0)
+    ${GPU_UPDATE_DEVICE('v0,rho0,p0,T0,pbeta0,b0,mach0')}$
 
   end subroutine usr_params_read
 
@@ -124,8 +128,8 @@ contains
 !   compilation it deals with this function.
 ! NOTE: This is ran on the GPU.
   subroutine addsource_usr(qdt, qt, wCT, wCTprim, wnew, x, split)
-      !$acc routine seq
       use mod_radiative_cooling, only: rc_fl,getvar_cooling_exact
+      ${GPU_ROUTINE_SEQ()}$
       double precision, intent(in) :: qdt, qt, wCT(nw_phys), wCTprim(nw_phys)
       double precision, intent(inout) :: wnew(nw_phys)
       double precision, intent(in) :: x(1:ndim)

--- a/tests/mhd/blast_wave_Cartesian_3D/mod_usr.fpp
+++ b/tests/mhd/blast_wave_Cartesian_3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -60,7 +64,7 @@ contains
 
   !> analytical fomula for the unit vectors along B
   pure real(dp) function bfield(x, idim) result(field)
-    !$acc routine seq
+    ${GPU_ROUTINE_SEQ()}$
     real(dp), intent(in)    :: x(1:ndim)
     integer, value, intent(in)     :: idim
 

--- a/tests/mhd/doubleGEM3D/mod_usr.fpp
+++ b/tests/mhd/doubleGEM3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -21,11 +25,11 @@ module mod_usr
 ! (4, n_modes, n_modes, 2:3)
   double precision, dimension(:,:,:,:), allocatable :: rand_1
 
-!$acc declare create(sheetl,rhorat,BB0,llx,lly,psi0bot,psi0top)
-!$acc declare create(llz,xmid,ymid,ysh1,ysh2,fkx,fky)
-!$acc declare create(zmid, sig_z, mode_root, n_modes)
-!$acc declare create(L, v_per, f_til)
-!$acc declare create(rand_1)
+  ${GPU_DECLARE_CREATE('sheetl,rhorat,BB0,llx,lly,psi0bot,psi0top')}$
+  ${GPU_DECLARE_CREATE('llz,xmid,ymid,ysh1,ysh2,fkx,fky')}$
+  ${GPU_DECLARE_CREATE('zmid, sig_z, mode_root, n_modes')}$
+  ${GPU_DECLARE_CREATE('L, v_per, f_til')}$
+  ${GPU_DECLARE_CREATE('rand_1')}$
 
 contains
 
@@ -53,8 +57,8 @@ contains
 111   close(unitpar) 
     end do
 
-!$acc update device(v_per,sig_z,f_til,mode_root,n_modes)
-!$acc update device(psi0bot,psi0top)
+    ${GPU_UPDATE_DEVICE('v_per,sig_z,f_til,mode_root,n_modes')}$
+    ${GPU_UPDATE_DEVICE('psi0bot,psi0top')}$
 
   end subroutine params_read_usr
 
@@ -101,9 +105,9 @@ contains
       call MPI_BCAST(rand_1, size(rand_1), MPI_DOUBLE_PRECISION, 0, icomm, ierrmpi)
     end if
 
-!$acc update device(sheetl,rhorat,BB0,llx,lly,llz,xmid,ymid,zmid,ysh1,ysh2,fkx,fky)
-!$acc update device(L)
-!$acc update device(rand_1)
+    ${GPU_UPDATE_DEVICE('sheetl,rhorat,BB0,llx,lly,llz,xmid,ymid,zmid,ysh1,ysh2,fkx,fky')}$
+    ${GPU_UPDATE_DEVICE('L')}$
+    ${GPU_UPDATE_DEVICE('rand_1')}$
 
     if (mype == 0) call print_params()
   end subroutine set_parameters_usr

--- a/tests/mhd/hotplate/mod_usr.fpp
+++ b/tests/mhd/hotplate/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
   use mod_amrvac
   use mod_physics
@@ -48,8 +52,8 @@ contains
   ! v=0 always at the plate, so e_tot = p/(gamma-1) + 0.5*|B|^2
   subroutine specialbound_usr(qt,ixGmin1,ixGmin2,ixGmin3,ixGmax1,ixGmax2,ixGmax3,&
      ixOmin1,ixOmin2,ixOmin3,ixOmax1,ixOmax2,ixOmax3,iB,w,x)
-    !$acc routine vector
     use mod_global_parameters
+    ${GPU_ROUTINE_VECTOR()}$
     implicit none
     double precision, intent(in)    :: qt
     integer, intent(in) :: ixGmin1,ixGmin2,ixGmin3,ixGmax1,ixGmax2,ixGmax3, &

--- a/tests/srhd/jet_3D/mod_usr.fpp
+++ b/tests/srhd/jet_3D/mod_usr.fpp
@@ -1,3 +1,7 @@
+#:mute
+#:include "../../../src/mod_gpu_directives.fpp"
+#:endmute
+
 module mod_usr
 
   use mod_amrvac
@@ -9,8 +13,8 @@ module mod_usr
   double precision :: rjet,zjet,rhob,etarho,rhojet,pb,zetap,pjet,lfacjet,vjet
   double precision :: Qjet, Mdotjet, p0val, t0val, tcross, vhead
 
-!$acc declare create(rjet,zjet,rhob,etarho,rhojet,pb,zetap,pjet,lfacjet,vjet)
-!$acc declare create(Qjet,Mdotjet,p0val,t0val,tcross,vhead)
+  ${GPU_DECLARE_CREATE('rjet,zjet,rhob,etarho,rhojet,pb,zetap,pjet,lfacjet,vjet')}$
+  ${GPU_DECLARE_CREATE('Qjet,Mdotjet,p0val,t0val,tcross,vhead')}$
 
 contains
 
@@ -46,13 +50,13 @@ contains
 111    close(unitpar)
     end do
 
-!$acc update device(rjet,zjet,rhob,etarho,pb,zetap,lfacjet)
+    ${GPU_UPDATE_DEVICE('rjet,zjet,rhob,etarho,pb,zetap,lfacjet')}$
 
     rhojet=etarho*rhob
     pjet=zetap*pb
     vjet=dsqrt(1.0d0-1.0d0/lfacjet**2)
 
-!$acc update device(rhojet,pjet,vjet)
+    ${GPU_UPDATE_DEVICE('rhojet,pjet,vjet')}$
 
   end subroutine usr_params_read
 
@@ -213,9 +217,9 @@ contains
        ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3,&
        ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3,&
        iB, w, x)
-    !$acc routine vector
     use mod_global_parameters
     use mod_physics_vars
+    ${GPU_ROUTINE_VECTOR()}$
     implicit none
     integer, intent(in) :: ixImin1, ixImin2, ixImin3, ixImax1, ixImax2, ixImax3
     integer, intent(in) :: ixOmin1, ixOmin2, ixOmin3, ixOmax1, ixOmax2, ixOmax3
@@ -231,7 +235,7 @@ contains
     select case(iB)
     case(5)
        ! select the first grid-internal layer above the boundary
-      !$acc loop collapse(3) vector
+      ${GPU_LOOP_VECTOR("collapse(3)")}$
       do ix3 = ixOmin3, ixOmax3
          do ix2 = ixOmin2, ixOmax2
             do ix1 = ixOmin1, ixOmax1
@@ -268,7 +272,7 @@ contains
 
       if(srhd_n_tracer>0)then
          do iw=1,srhd_n_tracer
-            !$acc loop collapse(3) vector
+            ${GPU_LOOP_VECTOR("collapse(3)")}$
             do ix3 = ixOmin3, ixOmax3
                do ix2 = ixOmin2, ixOmax2
                   do ix1 = ixOmin1, ixOmax1
@@ -285,7 +289,7 @@ contains
 
 ! Curently broken, cannot call anything here.      
       ! ! switch to conserved in ghost cells
-      ! !$acc loop collapse(3) vector
+      ! ${GPU_LOOP_VECTOR("collapse(3)")}$
       ! do ix3 = ixOmin3, ixOmax3
       !    do ix2 = ixOmin2, ixOmax2
       !       do ix1 = ixOmin1, ixOmax1

--- a/tests/srhd/jet_3D/mod_usr.fpp
+++ b/tests/srhd/jet_3D/mod_usr.fpp
@@ -346,13 +346,12 @@ contains
     ixGmin1, ixGmin2, ixGmin3, ixGmax1, ixGmax2, ixGmax3,&
     ixmin1,  ixmin2,  ixmin3,  ixmax1,  ixmax2,  ixmax3,&
     qt, w, x, refine, coarsen)
-#ifdef _OPENACC
-! NOTE: The Cray compiler fails when trying to inline this routine, for now
-!   disable inlining for Cray.
+#if defined(_CRAYFTN) && (defined(_OPENACC) || defined(_OPENMP))
+    ! disable inlining for Cray
     !dir$ inlinenever usr_refine_grid
 #endif
-    !$acc routine seq
     use mod_global_parameters
+    ${GPU_ROUTINE_SEQ()}$
     implicit none
     integer, intent(in) :: igrid, level
     integer, intent(in) :: ixGmin1, ixGmin2, ixGmin3, ixGmax1, ixGmax2, ixGmax3


### PR DESCRIPTION
OpenMP/OpenACC directives are now inserted by fypp, e.g.
`!$acc update device(time_advance)`
should now be written as
`${GPU_UPDATE_DEVICE('time_advance')}$`.
Fypp translates this to OpenACC, OpenMP, or nothing for a CPU build, similar to foap4.

Changes relevant for future AGILE development:
* `acc routine` / `omp declare target` directives must come _after_ any `use` statements in a subroutine (enforced by e.g. Cray).
*  compile-time variables (declared as `parameter`) must _not_ be explicitly copied to the GPU.
*  private scalars must be explicitly declared private: OpenACC uses `firstprivate` by default which just results in compiler warnings with some compilers, but works fine. OpenMP uses `shared` which leads to issues. Note: According to Claude this also applies to loop variables that are _not_ directly part of the part of the OpenMP clause, but I haven't checked this yet. 
* OpenMP cannot handle vector routines that use vector parallelization called from a gang-loop. Nvidia compiles it but it (sometimes) causes wrong results. Cray forces correctness but runs the vector loop on a single thread so performance is poor. We could get around this by inlining the relevant routines with Fypp, as I've done with the error estimation routines in `mod_errest`. TBD how we should handle this for user code. Note: Letting the compiler inline actual subroutines does _not_ work.

Remaining issues:
* OpenMP is ~25% slower, it generates some extra copies to/from the host. According to Claude another issue is that OpenMP cannot create thread-private arrays, so it places them in (slower) shared memory, but I haven't verified this.

Co-created by Claude